### PR TITLE
use ido for perspective-completion when desired

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -88,6 +88,10 @@ them in Emacs >= 23.2.  In older versions, this is identical to
 (defalias 'persp-killed-p 'persp-killed
   "Return whether the perspective CL-X has been killed.")
 
+(defvar persp-interactive-completion-function
+  (if ido-mode 'ido-completing-read 'completing-read)
+  "The function which is used by perspective.el to interactivly complete user input")
+
 (defvar persp-mode-hook nil
   "A hook that's run after `persp-mode' has been activated.")
 
@@ -248,7 +252,7 @@ Excludes NOT-FRAME, if given."
 DEFAULT is a default value for the prompt.
 
 REQUIRE-MATCH can take the same values as in `completing-read'."
-  (completing-read (concat "Perspective name"
+  (funcall persp-interactive-completion-function (concat "Perspective name"
                            (if default (concat " (default " default ")") "")
                            ": ")
                    (persp-names)
@@ -541,7 +545,8 @@ is non-nil or with prefix arg, don't switch to the new perspective."
   ;; TODO: Have some way of selecting which frame the perspective is imported from.
   (interactive "i\nP")
   (unless name
-    (setq name (completing-read "Import perspective: " (persp-all-names (selected-frame)) nil t)))
+    (setq name (funcall persp-interactive-completion-function
+                        "Import perspective: " (persp-all-names (selected-frame)) nil t)))
   (if (and (gethash name perspectives-hash)
            (not (yes-or-no-p (concat "Perspective `" name "' already exits. Continue? "))))
       (return-from persp-import))


### PR DESCRIPTION
I created the variable `persp-interactive-completion-function` which can be set to the desired completion function. Since I like fuzzy-matching I want to complete as much as possible with ido. It falls back to the normal `completing-read` function.
