### PR TITLE
Preserve buffer ordering in the ido-make-buffer-list-hook

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -684,9 +684,18 @@ it. In addition, if one exists already, runs BODY in it immediately."
        (with-perspective ,name ,@body))))
 
 (defun persp-set-ido-buffers ()
-  (setq ido-temp-list
-        (let ((names (remq nil (mapcar 'buffer-name (persp-buffers persp-curr)))))
-          (or (remove-if (lambda (name) (eq (string-to-char name) ? )) names) names))))
+  "Restrict the ido buffer to the current perspective."
+  (let ((persp-names
+         (remq nil (mapcar 'buffer-name (persp-buffers persp-curr))))
+        (indices (make-hash-table)))
+    (let ((i 0))
+      (dolist (elt ido-temp-list)
+        (puthash elt i indices)
+        (setq i (1+ i))))
+    (setq ido-temp-list
+          (sort persp-names (lambda (a b)
+                              (< (gethash a indices 10000)
+                                 (gethash b indices 10000)))))))
 
 (defun quick-perspective-keys ()
   "Bind quick key commands to switch to perspectives.


### PR DESCRIPTION
The existing hook overwrites the ido buffer list with the contents of `persp-buffers`, which removes the most-recent-first behavior in ido.

This patch sorts the perspectives buffer list based on the list provided by ido.
