### PR TITLE
keep persp-last persistent when using the with-perspecitve macro

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -263,12 +263,14 @@ REQUIRE-MATCH can take the same values as in `completing-read'."
   (declare (indent 1))
   (let ((old (gensym)))
     `(progn
-       (let ((,old (when persp-curr (persp-name persp-curr))))
+       (let ((,old (when persp-curr (persp-name persp-curr)))
+             (last-persp-cache persp-last))
          (unwind-protect
              (progn
                (persp-switch ,name)
                ,@body)
-           (when ,old (persp-switch ,old)))))))
+           (when ,old (persp-switch ,old)))
+         (setq persp-last last-persp-cache)))))
 
 (defun persp-new (name)
   "Return a new perspective with name NAME.


### PR DESCRIPTION
This patch makes sure, that the variable `persp-last` is restored after the use of the macro `with-perspective` . This is very important, since I use `persp-last` a lot to jump between two perspectives. Now whenever a new perspective is created, the `with-perspective` macro is used and the content of the `persp-last` variable is useless, because it points to the currently active perspective.
After the patch this is fixed and `persp-last` is consistent over the use of `with-perspective`
