### PR TITLE
fix missing global-persp-mode 

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -708,6 +708,14 @@ named collections of buffers and window configurations."
     (setq perspectives-hash nil)
     (setq global-mode-string (delq 'persp-modestring global-mode-string))))
 
+(defun turn-on-persp-mode ()
+  (when (not persp-mode)
+    (persp-mode 1)))
+
+;;;###autoload
+(define-globalized-minor-mode global-persp-mode
+  persp-mode turn-on-persp-mode)
+
 (defun persp-init-frame (frame)
   "Initialize the perspectives system in FRAME.
 By default, this uses the current frame."


### PR DESCRIPTION
this fixes the `persp-names: Wrong type argument: hash-table-p, nil` error for me when I call `persp-switch` in a fresh emacs instance (to turn persp-mode on i use the following code in my init.el

``` lisp
(add-hook 'after-init-hook #'persp-mode 1)
```

This PR fixes the wrong type argument error but switching perspectives still does not work, i.e., I can now enter a name of a perspective in `persp-switch` but it does not switch it (`persp-last` stays the same)

Any ideas?
(BTW: If I put (persp 1) in my init.el everything works, but I would like to use the after-init-hook)
