### PR TITLE
Fix cl-lib related warnings

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -28,6 +28,12 @@
 ;; available by default.
 
 (require 'cl-lib)
+
+;; 'cl' is still required because the use of 'lexical-let'.  'lexical-let' has
+;; been deprecated since emacs 24.1, and it should be replaced with true
+;; lexical bindings.  For more information, please see
+;; https://www.gnu.org/software/emacs/manual/html_node/cl/
+;; Obsolete-Lexical-Binding.html
 (require 'cl)
 
 (defvar ido-temp-list)


### PR DESCRIPTION
Fixed a few simple issues related to the recent switch to using `cl-lib`
from `cl`, which caused the package to fail to
load (https://github.com/nex3/perspective-el/issues/33).
- Add `cl-` prefix to `defun`, `loop`, and `return-from` expressions.
- Add back `(require 'cl)` because `lexical-let` is not defined in
  `cl-lib`.  Note that `lexical-let` has been deprecated since emacs
  24.1 (https://www.gnu.org/software/emacs/manual/html_node/cl/
  Obsolete-Lexical-Binding.html), true emacs binding should be used
  instead.

Ref #33 
