### PR TITLE
Define and run hook before switching perspectives

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -148,6 +148,10 @@ them in Emacs >= 23.2.  In older versions, this is identical to
   (if ido-mode 'ido-completing-read 'completing-read)
   "The function which is used by perspective.el to interactivly complete user input")
 
+(defvar persp-before-switch-hook nil
+  "A hook that's run before `persp-switch'.
+Run with the previous perspective as `persp-curr'.")
+
 (defvar persp-switch-hook nil
   "A hook that's run after `persp-switch'.
 Run with the newly created perspective as `persp-curr'.")
@@ -460,6 +464,7 @@ perspective's local variables are set."
       (setq persp-last persp-curr)
       (when (null persp)
         (setq persp (persp-new name)))
+      (run-hooks 'persp-before-switch-hook)
       (persp-activate persp)
       name))
   (run-hooks 'persp-switch-hook))


### PR DESCRIPTION
This patch adds a new hook that is run just before a new perspective is activated.

I'm using it to save and restore perspectives automatically with [revive](https://github.com/emacsmirror/revive/).

```elisp
(defun antonio/save-perspective-configuration ()
  "Save the current perspective windows configuration"
  (interactive)
  (if persp-curr
      (with-temp-file (format "~/.emacs.d/perspectives/%s" (persp-name persp-curr))
        (insert (prin1-to-string (current-window-configuration-printable))))))

(defun antonio/load-perspective-configuration ()
  "Load the current perspective windows configuration"
  (interactive)
  (let ((perspective-file (format "~/.emacs.d/perspectives/%s" (persp-name persp-curr))))
    (if (f-exists? perspective-file)
        (restore-window-configuration (read (f-read perspective-file)))))))

(add-hook 'persp-before-switch-hook 'antonio/save-perspective-configuration)
(add-hook 'persp-created-hook 'antonio/load-perspective-configuration))
```