### PR TITLE
advise set-window-buffer

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -735,6 +735,17 @@ See also `persp-add-buffer'."
           (with-selected-frame frame
             (persp-add-buffer buf)))))))
 
+(defadvice set-window-buffer (after persp-add-buffer-adv)
+  "Add BUFFER to the perspective for window's frame.
+
+See also `persp-add-buffer'."
+  (persp-protect
+    (let ((buf (ad-get-arg 1))
+          (frame (window-frame (ad-get-arg 0))))
+      (when (and buf frame)
+        (with-selected-frame frame
+          (persp-add-buffer buf))))))
+
 (defadvice switch-to-prev-buffer (around persp-ensure-buffer-in-persp)
   "Ensure that the selected buffer is in WINDOW's perspective."
   (let* ((window (window-normalize-window window t))
@@ -790,6 +801,7 @@ named collections of buffers and window configurations."
       (persp-protect
         (ad-activate 'switch-to-buffer)
         (ad-activate 'display-buffer)
+        (ad-activate 'set-window-buffer)
         (ad-activate 'switch-to-prev-buffer)
         (ad-activate 'recursive-edit)
         (ad-activate 'exit-recursive-edit)


### PR DESCRIPTION
primarily for slime's benefit, which uses set-window-buffer to
replace the window displaying *inferior-lisp* with a slime
repl buffer (when the slime-repl contrib is active)