### PR TITLE
Remove frame-local variables usage

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,0 @@
-persp-add-buffer doesn't automatically switch to the buffer
-persp-set-buffer doesn't automatically switch to the buffer
-persp-set-buffer doesn't close the window from the other frames

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,3 @@
+persp-add-buffer doesn't automatically switch to the buffer
+persp-set-buffer doesn't automatically switch to the buffer
+persp-set-buffer doesn't close the window from the other frames

--- a/perspective.el
+++ b/perspective.el
@@ -578,9 +578,9 @@ perspective and no others are killed."
     (setf (persp-killed (persp--current-persp)) t))
   (remhash name (frame-parameter nil 'perspectives-hash))
   (persp-update-modestring)
-  (when (equal name (persp-name (persp--last-persp)))
+  (when (and (persp--last-persp) (equal name (persp-name (persp--last-persp))))
     (set-frame-parameter nil 'persp-last nil))
-  (when (equal name (persp-name (persp--current-persp)))
+  (when (or (not (persp--current-persp)) (equal name (persp-name (persp--current-persp))))
     ;; Don't let persp-last get set to the deleted persp.
     (persp-let-frame-parameters ((persp-last (persp--last-persp)))
       (persp-switch (persp-find-some)))))

--- a/perspective.el
+++ b/perspective.el
@@ -196,54 +196,54 @@ Run with the activated perspective active.")
   (substitute-key-definition 'perspective-map nil persp-mode-map)
   (define-key persp-mode-map newkey 'perspective-map))
 
-;; make-variable-frame-local is obsolete according to the docs,
-;; but I don't want to have to manually munge frame-parameters
-;; all the time so I'm using it anyway.
-(make-variable-frame-local
- (defvar perspectives-hash nil
-   "A hash containing all perspectives. The keys are the
-perspectives' names. The values are persp structs,
-with the fields NAME, WINDOW-CONFIGURATION, BUFFERS,
-BUFFER-HISTORY, KILLED, POINT-MARKER, and LOCAL-VARIABLES.
+;; Keeping the variable definitions here since the docstrings might
+;; still be useful for developers.
 
-NAME is the name of the perspective.
+;; (make-variable-frame-local
+;;  (defvar perspectives-hash nil
+;;    "A hash containing all perspectives. The keys are the
+;; perspectives' names. The values are persp structs,
+;; with the fields NAME, WINDOW-CONFIGURATION, BUFFERS,
+;; BUFFER-HISTORY, KILLED, POINT-MARKER, and LOCAL-VARIABLES.
 
-WINDOW-CONFIGURATION is the configuration given by
-`current-window-configuration' last time the perspective was
-saved (if this isn't the current perspective, this is when the
-perspective was last active).
+;; NAME is the name of the perspective.
 
-BUFFERS is a list of buffer objects that are associated with this
-perspective.
+;; WINDOW-CONFIGURATION is the configuration given by
+;; `current-window-configuration' last time the perspective was
+;; saved (if this isn't the current perspective, this is when the
+;; perspective was last active).
 
-BUFFER-HISTORY is the list of buffer history values for this
-perspective.
+;; BUFFERS is a list of buffer objects that are associated with this
+;; perspective.
 
-KILLED is non-nil if the perspective has been killed.
+;; BUFFER-HISTORY is the list of buffer history values for this
+;; perspective.
 
-POINT-MARKER is the point position in the active buffer.
-Otherwise, when multiple windows are visiting the same buffer,
-all but one of their points will be overwritten.
+;; KILLED is non-nil if the perspective has been killed.
 
-LOCAL-VARIABLES is an alist from variable names to their
-perspective-local values."))
+;; POINT-MARKER is the point position in the active buffer.
+;; Otherwise, when multiple windows are visiting the same buffer,
+;; all but one of their points will be overwritten.
 
-(make-variable-frame-local
- (defvar persp-curr nil
-   "The current perspective."))
+;; LOCAL-VARIABLES is an alist from variable names to their
+;; perspective-local values."))
 
-(make-variable-frame-local
- (defvar persp-recursive nil
-   "The current perspective before beginning a recursive edit."))
+;; (make-variable-frame-local
+;;  (defvar persp-curr nil
+;;    "The current perspective."))
 
-(make-variable-frame-local
- (defvar persp-last nil
-   "The last perspective accessed before the current perspective."))
+;; (make-variable-frame-local
+;;  (defvar persp-recursive nil
+;;    "The current perspective before beginning a recursive edit."))
 
-(make-variable-frame-local
- (defvar persp-modestring nil
-   "The string displayed in the modeline representing the perspectives."))
-(put 'persp-modestring 'risky-local-variable t)
+;; (make-variable-frame-local
+;;  (defvar persp-last nil
+;;    "The last perspective accessed before the current perspective."))
+
+;; (make-variable-frame-local
+;;  (defvar persp-modestring nil
+;;    "The string displayed in the modeline representing the perspectives."))
+;; (put 'persp-modestring 'risky-local-variable t)
 
 (defvar persp-protected nil
   "Whether a perspective error should cause persp-mode to be disabled.
@@ -293,9 +293,9 @@ for the perspective."
       (dotimes (_ 2) (push (pop args) keywords)))
     (setq keywords (reverse keywords))
     `(let ((persp (make-persp-internal ,@keywords)))
-       (when persp-curr
-         (setf (persp-local-variables persp) (persp-local-variables persp-curr)))
-       (puthash (persp-name persp) persp perspectives-hash)
+       (when (frame-parameter nil 'persp-curr)
+         (setf (persp-local-variables persp) (persp-local-variables (frame-parameter nil 'persp-curr))))
+       (puthash (persp-name persp) persp (frame-parameter nil 'perspectives-hash))
        (with-perspective (persp-name persp)
          ,(when args
             ;; Body form given
@@ -307,21 +307,21 @@ for the perspective."
   "Save the current perspective state.
 Specifically, save the current window configuration and
 perspective-local variables to `persp-curr'"
-  (when persp-curr
-    (setf (persp-local-variables persp-curr)
+  (when (frame-parameter nil 'persp-curr)
+    (setf (persp-local-variables (frame-parameter nil 'persp-curr))
           (mapcar
            (lambda (c)
              (let ((name (car c)))
                (list name (symbol-value name))))
-           (persp-local-variables persp-curr)))
-    (setf (persp-buffer-history persp-curr) buffer-name-history)
-    (setf (persp-window-configuration persp-curr) (current-window-configuration))
-    (setf (persp-point-marker persp-curr) (point-marker))))
+           (persp-local-variables (frame-parameter nil 'persp-curr))))
+    (setf (persp-buffer-history (frame-parameter nil 'persp-curr)) buffer-name-history)
+    (setf (persp-window-configuration (frame-parameter nil 'persp-curr)) (current-window-configuration))
+    (setf (persp-point-marker (frame-parameter nil 'persp-curr)) (point-marker))))
 
 (defun persp-names ()
   "Return a list of the names of all perspectives, sorted alphabetically."
   (sort
-   (cl-loop for name being the hash-keys of perspectives-hash
+   (cl-loop for name being the hash-keys of (frame-parameter nil 'perspectives-hash)
             collect name)
    'string<))
 
@@ -352,14 +352,14 @@ REQUIRE-MATCH can take the same values as in `completing-read'."
   (declare (indent 1))
   (let ((old (cl-gensym)))
     `(progn
-       (let ((,old (when persp-curr (persp-name persp-curr)))
-             (last-persp-cache persp-last))
+       (let ((,old (when (frame-parameter nil 'persp-curr) (persp-name (frame-parameter nil 'persp-curr))))
+             (last-persp-cache (frame-parameter nil 'persp-last)))
          (unwind-protect
              (progn
                (persp-switch ,name)
                ,@body)
            (when ,old (persp-switch ,old)))
-         (setq persp-last last-persp-cache)))))
+         (set-frame-parameter nil 'persp-last last-persp-cache)))))
 
 (defun persp-new (name)
   "Return a new perspective with name NAME.
@@ -408,6 +408,10 @@ EVENT is the click event triggering this function call."
   (interactive "e")
   (persp-switch (format "%s" (car (posn-string (event-start event))))))
 
+(defun persp-mode-line ()
+  "Use this in the mode-line to show up-to-date value of `persp-modestring'."
+  (frame-parameter nil 'persp-modestring))
+
 (defun persp-update-modestring ()
   "Update `persp-modestring' to reflect the current perspectives.
 Has no effect when `persp-show-modestring' is nil."
@@ -415,16 +419,17 @@ Has no effect when `persp-show-modestring' is nil."
     (let ((open (list (nth 0 persp-modestring-dividers)))
           (close (list (nth 1 persp-modestring-dividers)))
           (sep (nth 2 persp-modestring-dividers)))
-     (setq persp-modestring
+      (set-frame-parameter nil 'persp-modestring
            (append open
                    (persp-intersperse (mapcar 'persp-format-name
                                               (persp-names)) sep)
                    close)))))
 
+
 (defun persp-format-name (name)
   "Format the perspective name given by NAME for display in `persp-modestring'."
   (let ((string-name (format "%s" name)))
-    (if (equal name (persp-name persp-curr))
+    (if (equal name (persp-name (frame-parameter nil 'persp-curr)))
         (propertize string-name 'face 'persp-selected-face)
       (propertize string-name
                   'local-map persp-mode-line-map
@@ -453,9 +458,9 @@ This is used for cycling between perspectives."
 (defun persp-switch-last ()
   "Switch to the perspective accessed before the current one."
   (interactive)
-  (unless persp-last
+  (unless (frame-parameter nil 'persp-last)
     (error "There is no last perspective"))
-  (persp-switch (persp-name persp-last)))
+  (persp-switch (persp-name (frame-parameter nil 'persp-last))))
 
 (defun persp-switch (name)
   "Switch to the perspective given by NAME.
@@ -466,10 +471,10 @@ that perspective are reactivated (see `persp-reactivate-buffers'),
 the perspective's window configuration is restored, and the
 perspective's local variables are set."
   (interactive "i")
-  (if (null name) (setq name (persp-prompt (and persp-last (persp-name persp-last)))))
-  (if (and persp-curr (equal name (persp-name persp-curr))) name
-    (let ((persp (gethash name perspectives-hash)))
-      (setq persp-last persp-curr)
+  (if (null name) (setq name (persp-prompt (and (frame-parameter nil 'persp-last) (persp-name (frame-parameter nil 'persp-last))))))
+  (if (and (frame-parameter nil 'persp-curr) (equal name (persp-name (frame-parameter nil 'persp-curr)))) name
+    (let ((persp (gethash name (frame-parameter nil 'perspectives-hash))))
+      (set-frame-parameter nil 'persp-last (frame-parameter nil 'persp-curr))
       (when (null persp)
         (setq persp (persp-new name)))
       (run-hooks 'persp-before-switch-hook)
@@ -481,7 +486,7 @@ perspective's local variables are set."
   "Activate the perspective given by the persp struct PERSP."
   (check-persp persp)
   (persp-save)
-  (setq persp-curr persp)
+  (set-frame-parameter nil 'persp-curr persp)
   (persp-set-local-variables (persp-local-variables persp))
   (persp-reactivate-buffers (persp-buffers persp))
   (setq buffer-name-history (persp-buffer-history persp))
@@ -508,7 +513,7 @@ See `persp-switch', `persp-get-quick'."
   "Switch to next perspective (to the right)."
   (interactive)
   (let* ((names (persp-names))
-         (pos (cl-position (persp-name persp-curr) names)))
+         (pos (cl-position (persp-name (frame-parameter nil 'persp-curr)) names)))
     (cond
      ((null pos) (persp-find-some))
      ((= pos (1- (length names)))
@@ -519,7 +524,7 @@ See `persp-switch', `persp-get-quick'."
   "Switch to previous perspective (to the left)."
   (interactive)
   (let* ((names (persp-names))
-         (pos (cl-position (persp-name persp-curr) names)))
+         (pos (cl-position (persp-name (frame-parameter nil 'persp-curr)) names)))
     (cond
      ((null pos) (persp-find-some))
      ((= pos 0)
@@ -539,9 +544,9 @@ perspective to switch to.  It tries:
 If none of these perspectives can be found, this function will
 create a new main perspective and return \"main\"."
   (cond
-   (persp-last (persp-name persp-last))
-   ((gethash persp-initial-frame-name perspectives-hash) persp-initial-frame-name)
-   ((> (hash-table-count perspectives-hash) 0) (car (persp-names)))
+   ((frame-parameter nil 'persp-last) (persp-name (frame-parameter nil 'persp-last)))
+   ((gethash persp-initial-frame-name (frame-parameter nil 'perspectives-hash)) persp-initial-frame-name)
+   ((> (hash-table-count (frame-parameter nil 'perspectives-hash)) 0) (car (persp-names)))
    (t (persp-activate
        (make-persp :name persp-initial-frame-name :buffers (buffer-list)
          :window-configuration (current-window-configuration)
@@ -557,8 +562,8 @@ See also `persp-switch' and `persp-remove-buffer'."
     (let ((read-buffer-function nil))
       (read-buffer "Add buffer to perspective: "))))
   (let ((buffer (get-buffer buffer)))
-    (unless (memq buffer (persp-buffers persp-curr))
-      (push buffer (persp-buffers persp-curr)))))
+    (unless (memq buffer (persp-buffers (frame-parameter nil 'persp-curr)))
+      (push buffer (persp-buffers (frame-parameter nil 'persp-curr))))))
 
 (defun persp-set-buffer (buffer-name)
   "Associate BUFFER-NAME with the current perspective and remove it from any other."
@@ -581,9 +586,9 @@ perspective that has the buffer.
 
 Prefers perspectives in the selected frame."
   (cl-loop for frame in (sort (frame-list) (lambda (frame1 frame2) (eq frame2 (selected-frame))))
-           do (cl-loop for persp being the hash-values of (with-selected-frame frame perspectives-hash)
+           do (cl-loop for persp being the hash-values of (frame-parameter frame 'perspectives-hash)
                        if (and (not (and (equal frame (selected-frame))
-                                         (equal (persp-name persp) (persp-name persp-curr))))
+                                         (equal (persp-name persp) (persp-name (frame-parameter frame 'persp-curr)))))
                                (memq buffer (persp-buffers persp)))
                        do (cl-return-from persp-buffer-in-other-p
                             (cons frame (persp-name persp)))))
@@ -596,7 +601,7 @@ Prefers perspectives in the selected frame."
     (let ((read-buffer-function nil))
       (read-buffer-to-switch "Switch to buffer: "))))
   (let ((buffer (window-normalize-buffer-to-switch-to buffer-or-name)))
-    (if (memq buffer (persp-buffers persp-curr))
+    (if (memq buffer (persp-buffers (frame-parameter nil 'persp-curr)))
         (switch-to-buffer buffer)
       (let ((other-persp (persp-buffer-in-other-p buffer)))
         (when (eq (car-safe other-persp) (selected-frame))
@@ -618,7 +623,7 @@ See also `persp-switch' and `persp-add-buffer'."
         ;;       rather than just the current buffer?
         ((eq buffer (current-buffer)) (bury-buffer))
         (t (bury-buffer buffer)))
-  (setf (persp-buffers persp-curr) (remq buffer (persp-buffers persp-curr))))
+  (setf (persp-buffers (frame-parameter nil 'persp-curr)) (remq buffer (persp-buffers (frame-parameter nil 'persp-curr)))))
 
 (defun persp-kill (name)
   "Kill the perspective given by NAME.
@@ -626,27 +631,27 @@ See also `persp-switch' and `persp-add-buffer'."
 Killing a perspective means that all buffers associated with that
 perspective and no others are killed."
   (interactive "i")
-  (if (null name) (setq name (persp-prompt (persp-name persp-curr) t)))
+  (if (null name) (setq name (persp-prompt (persp-name (frame-parameter nil 'persp-curr)) t)))
   (with-perspective name
     (run-hooks 'persp-killed-hook)
-    (mapc 'persp-remove-buffer (persp-buffers persp-curr))
-    (setf (persp-killed persp-curr) t))
-  (remhash name perspectives-hash)
+    (mapc 'persp-remove-buffer (persp-buffers (frame-parameter nil 'persp-curr)))
+    (setf (persp-killed (frame-parameter nil 'persp-curr)) t))
+  (remhash name (frame-parameter nil 'perspectives-hash))
   (persp-update-modestring)
-  (when (equal name (persp-name persp-last))
-    (setq persp-last nil))
-  (when (equal name (persp-name persp-curr))
+  (when (equal name (persp-name (frame-parameter nil 'persp-last)))
+    (set-frame-parameter nil 'persp-last nil))
+  (when (equal name (persp-name (frame-parameter nil 'persp-curr)))
     ;; Don't let persp-last get set to the deleted persp.
-    (persp-frame-local-let ((persp-last persp-last)) (persp-switch (persp-find-some)))))
+    (persp-frame-local-let ((persp-last (frame-parameter nil 'persp-last))) (persp-switch (persp-find-some)))))
 
 (defun persp-rename (name)
   "Rename the current perspective to NAME."
   (interactive "sNew name: ")
-  (if (gethash name perspectives-hash)
+  (if (gethash name (frame-parameter nil 'perspectives-hash))
       (persp-error "Perspective `%s' already exists" name)
-    (remhash (persp-name persp-curr) perspectives-hash)
-    (puthash name persp-curr perspectives-hash)
-    (setf (persp-name persp-curr) name)
+    (remhash (persp-name (frame-parameter nil 'persp-curr)) (frame-parameter nil 'perspectives-hash))
+    (puthash name (frame-parameter nil 'persp-curr) (frame-parameter nil 'perspectives-hash))
+    (setf (persp-name (frame-parameter nil 'persp-curr)) name)
     (persp-update-modestring)))
 
 (cl-defun persp-all-get (name not-frame)
@@ -658,7 +663,7 @@ copied across frames."
   (dolist (frame (frame-list))
     (unless (equal frame not-frame)
       (with-selected-frame frame
-        (let ((persp (gethash name perspectives-hash)))
+        (let ((persp (gethash name (frame-parameter nil 'perspectives-hash))))
           (if persp (cl-return-from persp-all-get (persp-buffers persp))))))))
 
 (defun persp-read-buffer (prompt &optional def require-match)
@@ -691,7 +696,7 @@ With a prefix arg, uses the old `read-buffer' instead."
 
 (defun persp-complete-buffer ()
   "Perform completion on all buffers within the current perspective."
-  (lexical-let ((persp-names (mapcar 'buffer-name (persp-buffers persp-curr))))
+  (lexical-let ((persp-names (mapcar 'buffer-name (persp-buffers (frame-parameter nil 'persp-curr)))))
     (apply-partially 'completion-table-with-predicate
                      (or minibuffer-completion-table 'internal-complete-buffer)
                      (lambda (name)
@@ -706,7 +711,7 @@ is non-nil or with prefix arg, don't switch to the new perspective."
   (unless name
     (setq name (funcall persp-interactive-completion-function
                         "Import perspective: " (persp-all-names (selected-frame)) nil t)))
-  (if (and (gethash name perspectives-hash)
+  (if (and (gethash name (frame-parameter nil 'perspectives-hash))
            (not (yes-or-no-p (concat "Perspective `" name "' already exits. Continue? "))))
       (cl-return-from persp-import))
   (let ((buffers (persp-all-get name (selected-frame)))
@@ -763,16 +768,16 @@ See also `persp-add-buffer'."
 
     (let ((buffer (window-buffer window)))
       (with-selected-frame frame
-        (unless (memq buffer (persp-buffers persp-curr))
+        (unless (memq buffer (persp-buffers (frame-parameter nil 'persp-curr)))
           ;; If a buffer from outside this perspective was selected, it's because
           ;; this perspective is out of buffers. For lack of any better option, we
           ;; recreate the scratch buffer.
           ;;
           ;; If we were just in a scratch buffer, change the name slightly.
           ;; Otherwise our new buffer will get deleted too.
-          (let ((name (concat "*scratch* (" (persp-name persp-curr) ")")))
+          (let ((name (concat "*scratch* (" (persp-name (frame-parameter nil 'persp-curr)) ")")))
             (when (and bury-or-kill (equal name (buffer-name old-buffer)))
-              (setq name (concat "*scratch*  (" (persp-name persp-curr) ")")))
+              (setq name (concat "*scratch*  (" (persp-name (frame-parameter nil 'persp-curr)) ")")))
             (with-selected-window window
               (switch-to-buffer name)
               (funcall initial-major-mode))))))))
@@ -781,8 +786,8 @@ See also `persp-add-buffer'."
   "Preserve the current perspective when entering a recursive edit."
   (persp-protect
     (persp-save)
-    (persp-frame-local-let ((persp-recursive persp-curr))
-      (let ((old-hash (copy-hash-table perspectives-hash)))
+    (persp-frame-local-let ((persp-recursive (frame-parameter nil 'persp-curr)))
+      (let ((old-hash (copy-hash-table (frame-parameter nil 'perspectives-hash))))
         ad-do-it
         ;; We want the buffer lists that were created in the recursive edit,
         ;; but not the window configurations
@@ -790,13 +795,13 @@ See also `persp-add-buffer'."
                    (let ((persp (gethash key old-hash)))
                      (when persp
                        (setf (persp-buffers persp) (persp-buffers new-persp)))))
-                 perspectives-hash)
-        (setq perspectives-hash old-hash)))))
+                 (frame-parameter nil 'perspectives-hash))
+        (set-frame-parameter nil 'perspectives-hash old-hash)))))
 
 (defadvice exit-recursive-edit (before persp-restore-after-recursive-edit)
   "Restore the old perspective when exiting a recursive edit."
   (persp-protect
-    (if persp-recursive (persp-switch (persp-name persp-recursive)))))
+    (if (frame-parameter nil 'persp-recursive) (persp-switch (persp-name (frame-parameter nil 'persp-recursive))))))
 
 ;;;###autoload
 (define-minor-mode persp-mode
@@ -817,15 +822,18 @@ named collections of buffers and window configurations."
         (add-hook 'ido-make-buffer-list-hook 'persp-set-ido-buffers)
         (setq read-buffer-function 'persp-read-buffer)
         (mapc 'persp-init-frame (frame-list))
-        (setf (persp-buffers persp-curr) (buffer-list))
+        (setf (persp-buffers (frame-parameter nil 'persp-curr)) (buffer-list))
 
         (run-hooks 'persp-mode-hook))
     (ad-deactivate-regexp "^persp-.*")
     (remove-hook 'after-make-frame-functions 'persp-init-frame)
     (remove-hook 'ido-make-buffer-list-hook 'persp-set-ido-buffers)
     (setq read-buffer-function nil)
-    (setq perspectives-hash nil)
-    (setq global-mode-string (delq 'persp-modestring global-mode-string))))
+    (set-frame-parameter nil 'perspectives-hash nil)
+    (setq global-mode-string (delete '(:eval (persp-mode-line)) global-mode-string))
+    (set-default 'header-line-format (delete '(:eval (persp-mode-line)) header-line-format))
+    (unless (delete "" header-line-format)
+      (set-default 'header-line-format nil))))
 
 (defun persp-init-frame (frame)
   "Initialize the perspectives system in FRAME.
@@ -837,16 +845,16 @@ By default, this uses the current frame."
 
     ;; Don't set these variables in modify-frame-parameters
     ;; because that won't do anything if they've already been accessed
-    (setq perspectives-hash (make-hash-table :test 'equal :size 10))
+    (set-frame-parameter frame 'perspectives-hash (make-hash-table :test 'equal :size 10))
 
     (when persp-show-modestring
       (if (eq persp-show-modestring 'header)
           (let ((val (or (default-value 'header-line-format) '(""))))
-            (unless (memq 'persp-modestring val)
-              (set-default 'header-line-format (append val '(persp-modestring)))))
+            (unless (member '(:eval (persp-mode-line)) val)
+              (set-default 'header-line-format (append val '((:eval (persp-mode-line)))))))
         (setq global-mode-string (or global-mode-string '("")))
-        (unless (memq 'persp-modestring global-mode-string)
-          (setq global-mode-string (append global-mode-string '(persp-modestring)))))
+        (unless (member '(:eval (persp-mode-line)) global-mode-string)
+          (setq global-mode-string (append global-mode-string '((:eval (persp-mode-line)))))))
       (persp-update-modestring))
 
     (persp-activate
@@ -860,10 +868,10 @@ This means that whenever a new perspective is switched into, the
 variable will take on its local value for that perspective.  When
 a new perspective is created, the variable will inherit its value
 from the current perspective at time of creation."
-  (unless (assq variable (persp-local-variables persp-curr))
+  (unless (assq variable (persp-local-variables (frame-parameter nil 'persp-curr)))
     (let ((entry (list variable (symbol-value variable))))
       (dolist (frame (frame-list))
-        (cl-loop for persp being the hash-values of (with-selected-frame frame perspectives-hash)
+        (cl-loop for persp being the hash-values of (frame-parameter frame 'perspectives-hash)
                  do (push entry (persp-local-variables persp)))))))
 
 (defmacro persp-setup-for (name &rest body)
@@ -874,16 +882,16 @@ it. In addition, if one exists already, runs BODY in it immediately."
   `(progn
      (add-hook 'persp-created-hook
                (lambda ()
-                 (when (string= (persp-name persp-curr) ,name)
+                 (when (string= (persp-name (frame-parameter nil 'persp-curr)) ,name)
                    ,@body))
                'append)
-     (when (gethash ,name perspectives-hash)
+     (when (gethash ,name (frame-parameter nil 'perspectives-hash))
        (with-perspective ,name ,@body))))
 
 (defun persp-set-ido-buffers ()
   "Restrict the ido buffer to the current perspective."
   (let ((persp-names
-         (remq nil (mapcar 'buffer-name (persp-buffers persp-curr))))
+         (remq nil (mapcar 'buffer-name (persp-buffers (frame-parameter nil 'persp-curr)))))
         (indices (make-hash-table :test 'equal)))
     (cl-loop for elt in ido-temp-list
              for i upfrom 0
@@ -908,7 +916,7 @@ perspective beginning with the given letter."
 (defun persp-turn-off-modestring ()
   "Deactivate the perspective modestring."
   (interactive)
-  (setq persp-modestring nil)
+  (set-frame-parameter nil 'persp-modestring nil)
   (setq persp-show-modestring nil))
 
 (defun persp-turn-on-modestring ()

--- a/perspective.el
+++ b/perspective.el
@@ -1,13 +1,13 @@
 ;;; perspective.el --- switch between named "perspectives" of the editor
 
-;; Copyright (C) 2008-2015 Natalie Weizenbaum <nex342@gmail.com>
+;; Copyright (C) 2008-2018 Natalie Weizenbaum <nex342@gmail.com>
 ;;
 ;; Licensed under the same terms as Emacs and under the MIT license.
 
 ;; Author: Natalie Weizenbaum <nex342@gmail.com>
 ;; URL: http://github.com/nex3/perspective-el
 ;; Package-Requires: ((cl-lib "0.5"))
-;; Version: 1.12
+;; Version: 2.0
 ;; Created: 2008-03-05
 ;; By: Natalie Weizenbaum <nex342@gmail.com>
 ;; Keywords: workspace, convenience, frames

--- a/perspective.el
+++ b/perspective.el
@@ -173,13 +173,15 @@ Run with the activated perspective active.")
 (define-key perspective-map (kbd "<left>") 'persp-prev)
 (define-key perspective-map persp-mode-prefix-key 'persp-switch-last)
 
-(defun persp-curr ()
-  "Get the current perspective in the active frame."
-  (frame-parameter nil 'persp--curr))
+(defun persp-curr (&optional frame)
+  "Get the current perspective in FRAME.
+FRAME defaults to the currently selected frame."
+  (frame-parameter frame 'persp--curr))
 
-(defun persp-last ()
-  "Get the last active perspective for the active frame."
-  (frame-parameter nil 'persp--last))
+(defun persp-last (&optional frame)
+  "Get the last active perspective in FRAME.
+FRAME defaults to the currently selected frame."
+  (frame-parameter frame 'persp--last))
 
 (defun persp-mode-set-prefix-key (newkey)
   "Set the prefix key to activate persp-mode"
@@ -528,7 +530,7 @@ Prefers perspectives in the selected frame."
   (cl-loop for frame in (sort (frame-list) (lambda (frame1 frame2) (eq frame2 (selected-frame))))
            do (cl-loop for persp being the hash-values of (frame-parameter frame 'persp--hash)
                        if (and (not (and (equal frame (selected-frame))
-                                         (equal (persp-name persp) (persp-name (frame-parameter frame 'persp--curr)))))
+                                         (equal (persp-name persp) (persp-name (persp-curr frame)))))
                                (memq buffer (persp-buffers persp)))
                        do (cl-return-from persp-buffer-in-other-p
                             (cons frame (persp-name persp)))))

--- a/perspective.el
+++ b/perspective.el
@@ -173,11 +173,11 @@ Run with the activated perspective active.")
 (define-key perspective-map (kbd "<left>") 'persp-prev)
 (define-key perspective-map persp-mode-prefix-key 'persp-switch-last)
 
-(defun persp--current-persp ()
+(defun persp-current-persp ()
   "Get the current perspective in the active frame."
   (frame-parameter nil 'persp-curr))
 
-(defun persp--last-persp ()
+(defun persp-last-persp ()
   "Get the last active perspective for the active frame."
   (frame-parameter nil 'persp-last))
 
@@ -234,8 +234,8 @@ for the perspective."
       (dotimes (_ 2) (push (pop args) keywords)))
     (setq keywords (reverse keywords))
     `(let ((persp (make-persp-internal ,@keywords)))
-       (when (persp--current-persp)
-         (setf (persp-local-variables persp) (persp-local-variables (persp--current-persp))))
+       (when (persp-current-persp)
+         (setf (persp-local-variables persp) (persp-local-variables (persp-current-persp))))
        (puthash (persp-name persp) persp (frame-parameter nil 'perspectives-hash))
        (with-perspective (persp-name persp)
          ,(when args
@@ -248,16 +248,16 @@ for the perspective."
   "Save the current perspective state.
 Specifically, save the current window configuration and
 perspective-local variables to `persp-curr'"
-  (when (persp--current-persp)
-    (setf (persp-local-variables (persp--current-persp))
+  (when (persp-current-persp)
+    (setf (persp-local-variables (persp-current-persp))
           (mapcar
            (lambda (c)
              (let ((name (car c)))
                (list name (symbol-value name))))
-           (persp-local-variables (persp--current-persp))))
-    (setf (persp-buffer-history (persp--current-persp)) buffer-name-history)
-    (setf (persp-window-configuration (persp--current-persp)) (current-window-configuration))
-    (setf (persp-point-marker (persp--current-persp)) (point-marker))))
+           (persp-local-variables (persp-current-persp))))
+    (setf (persp-buffer-history (persp-current-persp)) buffer-name-history)
+    (setf (persp-window-configuration (persp-current-persp)) (current-window-configuration))
+    (setf (persp-point-marker (persp-current-persp)) (point-marker))))
 
 (defun persp-names ()
   "Return a list of the names of all perspectives, sorted alphabetically."
@@ -293,8 +293,8 @@ REQUIRE-MATCH can take the same values as in `completing-read'."
   (declare (indent 1))
   (let ((old (cl-gensym)))
     `(progn
-       (let ((,old (when (persp--current-persp) (persp-name (persp--current-persp))))
-             (last-persp-cache (persp--last-persp)))
+       (let ((,old (when (persp-current-persp) (persp-name (persp-current-persp))))
+             (last-persp-cache (persp-last-persp)))
          (unwind-protect
              (progn
                (persp-switch ,name)
@@ -369,7 +369,7 @@ Has no effect when `persp-show-modestring' is nil."
 (defun persp-format-name (name)
   "Format the perspective name given by NAME for display in the modeline."
   (let ((string-name (format "%s" name)))
-    (if (equal name (persp-name (persp--current-persp)))
+    (if (equal name (persp-name (persp-current-persp)))
         (propertize string-name 'face 'persp-selected-face)
       (propertize string-name
                   'local-map persp-mode-line-map
@@ -398,9 +398,9 @@ This is used for cycling between perspectives."
 (defun persp-switch-last ()
   "Switch to the perspective accessed before the current one."
   (interactive)
-  (unless (persp--last-persp)
+  (unless (persp-last-persp)
     (error "There is no last perspective"))
-  (persp-switch (persp-name (persp--last-persp))))
+  (persp-switch (persp-name (persp-last-persp))))
 
 (defun persp-switch (name)
   "Switch to the perspective given by NAME.
@@ -411,10 +411,10 @@ that perspective are reactivated (see `persp-reactivate-buffers'),
 the perspective's window configuration is restored, and the
 perspective's local variables are set."
   (interactive "i")
-  (if (null name) (setq name (persp-prompt (and (persp--last-persp) (persp-name (persp--last-persp))))))
-  (if (and (persp--current-persp) (equal name (persp-name (persp--current-persp)))) name
+  (if (null name) (setq name (persp-prompt (and (persp-last-persp) (persp-name (persp-last-persp))))))
+  (if (and (persp-current-persp) (equal name (persp-name (persp-current-persp)))) name
     (let ((persp (gethash name (frame-parameter nil 'perspectives-hash))))
-      (set-frame-parameter nil 'persp-last (persp--current-persp))
+      (set-frame-parameter nil 'persp-last (persp-current-persp))
       (when (null persp)
         (setq persp (persp-new name)))
       (run-hooks 'persp-before-switch-hook)
@@ -453,7 +453,7 @@ See `persp-switch', `persp-get-quick'."
   "Switch to next perspective (to the right)."
   (interactive)
   (let* ((names (persp-names))
-         (pos (cl-position (persp-name (persp--current-persp)) names)))
+         (pos (cl-position (persp-name (persp-current-persp)) names)))
     (cond
      ((null pos) (persp-find-some))
      ((= pos (1- (length names)))
@@ -464,7 +464,7 @@ See `persp-switch', `persp-get-quick'."
   "Switch to previous perspective (to the left)."
   (interactive)
   (let* ((names (persp-names))
-         (pos (cl-position (persp-name (persp--current-persp)) names)))
+         (pos (cl-position (persp-name (persp-current-persp)) names)))
     (cond
      ((null pos) (persp-find-some))
      ((= pos 0)
@@ -484,7 +484,7 @@ perspective to switch to.  It tries:
 If none of these perspectives can be found, this function will
 create a new main perspective and return \"main\"."
   (cond
-   ((persp--last-persp) (persp-name (persp--last-persp)))
+   ((persp-last-persp) (persp-name (persp-last-persp)))
    ((gethash persp-initial-frame-name (frame-parameter nil 'perspectives-hash)) persp-initial-frame-name)
    ((> (hash-table-count (frame-parameter nil 'perspectives-hash)) 0) (car (persp-names)))
    (t (persp-activate
@@ -502,8 +502,8 @@ See also `persp-switch' and `persp-remove-buffer'."
     (let ((read-buffer-function nil))
       (read-buffer "Add buffer to perspective: "))))
   (let ((buffer (get-buffer buffer)))
-    (unless (memq buffer (persp-buffers (persp--current-persp)))
-      (push buffer (persp-buffers (persp--current-persp))))))
+    (unless (memq buffer (persp-buffers (persp-current-persp)))
+      (push buffer (persp-buffers (persp-current-persp))))))
 
 (defun persp-set-buffer (buffer-name)
   "Associate BUFFER-NAME with the current perspective and remove it from any other."
@@ -541,7 +541,7 @@ Prefers perspectives in the selected frame."
     (let ((read-buffer-function nil))
       (read-buffer-to-switch "Switch to buffer: "))))
   (let ((buffer (window-normalize-buffer-to-switch-to buffer-or-name)))
-    (if (memq buffer (persp-buffers (persp--current-persp)))
+    (if (memq buffer (persp-buffers (persp-current-persp)))
         (switch-to-buffer buffer)
       (let ((other-persp (persp-buffer-in-other-p buffer)))
         (when (eq (car-safe other-persp) (selected-frame))
@@ -563,7 +563,7 @@ See also `persp-switch' and `persp-add-buffer'."
         ;;       rather than just the current buffer?
         ((eq buffer (current-buffer)) (bury-buffer))
         (t (bury-buffer buffer)))
-  (setf (persp-buffers (persp--current-persp)) (remq buffer (persp-buffers (persp--current-persp)))))
+  (setf (persp-buffers (persp-current-persp)) (remq buffer (persp-buffers (persp-current-persp)))))
 
 (defun persp-kill (name)
   "Kill the perspective given by NAME.
@@ -571,18 +571,18 @@ See also `persp-switch' and `persp-add-buffer'."
 Killing a perspective means that all buffers associated with that
 perspective and no others are killed."
   (interactive "i")
-  (if (null name) (setq name (persp-prompt (persp-name (persp--current-persp)) t)))
+  (if (null name) (setq name (persp-prompt (persp-name (persp-current-persp)) t)))
   (with-perspective name
     (run-hooks 'persp-killed-hook)
-    (mapc 'persp-remove-buffer (persp-buffers (persp--current-persp)))
-    (setf (persp-killed (persp--current-persp)) t))
+    (mapc 'persp-remove-buffer (persp-buffers (persp-current-persp)))
+    (setf (persp-killed (persp-current-persp)) t))
   (remhash name (frame-parameter nil 'perspectives-hash))
   (persp-update-modestring)
-  (when (and (persp--last-persp) (equal name (persp-name (persp--last-persp))))
+  (when (and (persp-last-persp) (equal name (persp-name (persp-last-persp))))
     (set-frame-parameter nil 'persp-last nil))
-  (when (or (not (persp--current-persp)) (equal name (persp-name (persp--current-persp))))
+  (when (or (not (persp-current-persp)) (equal name (persp-name (persp-current-persp))))
     ;; Don't let persp-last get set to the deleted persp.
-    (persp-let-frame-parameters ((persp-last (persp--last-persp)))
+    (persp-let-frame-parameters ((persp-last (persp-last-persp)))
       (persp-switch (persp-find-some)))))
 
 (defun persp-rename (name)
@@ -590,9 +590,9 @@ perspective and no others are killed."
   (interactive "sNew name: ")
   (if (gethash name (frame-parameter nil 'perspectives-hash))
       (persp-error "Perspective `%s' already exists" name)
-    (remhash (persp-name (persp--current-persp)) (frame-parameter nil 'perspectives-hash))
-    (puthash name (persp--current-persp) (frame-parameter nil 'perspectives-hash))
-    (setf (persp-name (persp--current-persp)) name)
+    (remhash (persp-name (persp-current-persp)) (frame-parameter nil 'perspectives-hash))
+    (puthash name (persp-current-persp) (frame-parameter nil 'perspectives-hash))
+    (setf (persp-name (persp-current-persp)) name)
     (persp-update-modestring)))
 
 (cl-defun persp-all-get (name not-frame)
@@ -637,7 +637,7 @@ With a prefix arg, uses the old `read-buffer' instead."
 
 (defun persp-complete-buffer ()
   "Perform completion on all buffers within the current perspective."
-  (lexical-let ((persp-names (mapcar 'buffer-name (persp-buffers (persp--current-persp)))))
+  (lexical-let ((persp-names (mapcar 'buffer-name (persp-buffers (persp-current-persp)))))
     (apply-partially 'completion-table-with-predicate
                      (or minibuffer-completion-table 'internal-complete-buffer)
                      (lambda (name)
@@ -709,16 +709,16 @@ See also `persp-add-buffer'."
 
     (let ((buffer (window-buffer window)))
       (with-selected-frame frame
-        (unless (memq buffer (persp-buffers (persp--current-persp)))
+        (unless (memq buffer (persp-buffers (persp-current-persp)))
           ;; If a buffer from outside this perspective was selected, it's because
           ;; this perspective is out of buffers. For lack of any better option, we
           ;; recreate the scratch buffer.
           ;;
           ;; If we were just in a scratch buffer, change the name slightly.
           ;; Otherwise our new buffer will get deleted too.
-          (let ((name (concat "*scratch* (" (persp-name (persp--current-persp)) ")")))
+          (let ((name (concat "*scratch* (" (persp-name (persp-current-persp)) ")")))
             (when (and bury-or-kill (equal name (buffer-name old-buffer)))
-              (setq name (concat "*scratch*  (" (persp-name (persp--current-persp)) ")")))
+              (setq name (concat "*scratch*  (" (persp-name (persp-current-persp)) ")")))
             (with-selected-window window
               (switch-to-buffer name)
               (funcall initial-major-mode))))))))
@@ -727,7 +727,7 @@ See also `persp-add-buffer'."
   "Preserve the current perspective when entering a recursive edit."
   (persp-protect
     (persp-save)
-    (persp-let-frame-parameters ((persp-recursive (persp--current-persp)))
+    (persp-let-frame-parameters ((persp-recursive (persp-current-persp)))
       (let ((old-hash (copy-hash-table (frame-parameter nil 'perspectives-hash))))
         ad-do-it
         ;; We want the buffer lists that were created in the recursive edit,
@@ -763,7 +763,7 @@ named collections of buffers and window configurations."
         (add-hook 'ido-make-buffer-list-hook 'persp-set-ido-buffers)
         (setq read-buffer-function 'persp-read-buffer)
         (mapc 'persp-init-frame (frame-list))
-        (setf (persp-buffers (persp--current-persp)) (buffer-list))
+        (setf (persp-buffers (persp-current-persp)) (buffer-list))
 
         (run-hooks 'persp-mode-hook))
     (ad-deactivate-regexp "^persp-.*")
@@ -810,7 +810,7 @@ This means that whenever a new perspective is switched into, the
 variable will take on its local value for that perspective.  When
 a new perspective is created, the variable will inherit its value
 from the current perspective at time of creation."
-  (unless (assq variable (persp-local-variables (persp--current-persp)))
+  (unless (assq variable (persp-local-variables (persp-current-persp)))
     (let ((entry (list variable (symbol-value variable))))
       (dolist (frame (frame-list))
         (cl-loop for persp being the hash-values of (frame-parameter frame 'perspectives-hash)
@@ -824,7 +824,7 @@ it. In addition, if one exists already, runs BODY in it immediately."
   `(progn
      (add-hook 'persp-created-hook
                (lambda ()
-                 (when (string= (persp-name (persp--current-persp)) ,name)
+                 (when (string= (persp-name (persp-current-persp)) ,name)
                    ,@body))
                'append)
      (when (gethash ,name (frame-parameter nil 'perspectives-hash))
@@ -833,7 +833,7 @@ it. In addition, if one exists already, runs BODY in it immediately."
 (defun persp-set-ido-buffers ()
   "Restrict the ido buffer to the current perspective."
   (let ((persp-names
-         (remq nil (mapcar 'buffer-name (persp-buffers (persp--current-persp)))))
+         (remq nil (mapcar 'buffer-name (persp-buffers (persp-current-persp)))))
         (indices (make-hash-table :test 'equal)))
     (cl-loop for elt in ido-temp-list
              for i upfrom 0

--- a/perspective.el
+++ b/perspective.el
@@ -774,6 +774,7 @@ named collections of buffers and window configurations."
     (setq global-mode-string (delete '(:eval (persp-mode-line)) global-mode-string))
     (set-default 'header-line-format (delete '(:eval (persp-mode-line)) header-line-format))
     (unless (delete "" header-line-format)
+      ;; need to set header-line-format to nil to completely remove the header from the buffer
       (set-default 'header-line-format nil))))
 
 (defun persp-init-frame (frame)

--- a/perspective.el
+++ b/perspective.el
@@ -50,8 +50,8 @@
   :group 'perspective-mode)
 
 (defcustom persp-show-modestring t
-  "Determines if `persp-modestring' is shown in the modeline.
-If the value is 'header, `persp-modestring' is shown in the
+  "Determines if the list of perspectives is shown in the modeline.
+If the value is 'header, the list of perspectives is shown in the
 header line instead."
   :group 'perspective-mode
   :type '(choice (const :tag "Off" nil)
@@ -59,7 +59,7 @@ header line instead."
                  (const :tag "Header" 'header)))
 
 (defcustom persp-modestring-dividers '("[" "]" "|")
-  "Plist of strings used to created `persp-modestring'.
+  "Plist of strings used to create the string shown in the modeline.
 First string is the start of the modestring, second is the
 closing of the mode string, and the last is the divider between
 perspectives."
@@ -343,11 +343,11 @@ EVENT is the click event triggering this function call."
   (persp-switch (format "%s" (car (posn-string (event-start event))))))
 
 (defun persp-mode-line ()
-  "Use this in the mode-line to show up-to-date value of `persp-modestring'."
+  "Return the string displayed in the modeline representing the perspectives."
   (frame-parameter nil 'persp-modestring))
 
 (defun persp-update-modestring ()
-  "Update `persp-modestring' to reflect the current perspectives.
+  "Update the string to reflect the current perspectives.
 Has no effect when `persp-show-modestring' is nil."
   (when persp-show-modestring
     (let ((open (list (nth 0 persp-modestring-dividers)))
@@ -361,7 +361,7 @@ Has no effect when `persp-show-modestring' is nil."
 
 
 (defun persp-format-name (name)
-  "Format the perspective name given by NAME for display in `persp-modestring'."
+  "Format the perspective name given by NAME for display in the modeline."
   (let ((string-name (format "%s" name)))
     (if (equal name (persp-name (persp--current-persp)))
         (propertize string-name 'face 'persp-selected-face)

--- a/perspective.el
+++ b/perspective.el
@@ -166,55 +166,6 @@ Run with the activated perspective active.")
   (substitute-key-definition 'perspective-map nil persp-mode-map)
   (define-key persp-mode-map newkey 'perspective-map))
 
-;; Keeping the variable definitions here since the docstrings might
-;; still be useful for developers.
-
-;; (make-variable-frame-local
-;;  (defvar perspectives-hash nil
-;;    "A hash containing all perspectives. The keys are the
-;; perspectives' names. The values are persp structs,
-;; with the fields NAME, WINDOW-CONFIGURATION, BUFFERS,
-;; BUFFER-HISTORY, KILLED, POINT-MARKER, and LOCAL-VARIABLES.
-
-;; NAME is the name of the perspective.
-
-;; WINDOW-CONFIGURATION is the configuration given by
-;; `current-window-configuration' last time the perspective was
-;; saved (if this isn't the current perspective, this is when the
-;; perspective was last active).
-
-;; BUFFERS is a list of buffer objects that are associated with this
-;; perspective.
-
-;; BUFFER-HISTORY is the list of buffer history values for this
-;; perspective.
-
-;; KILLED is non-nil if the perspective has been killed.
-
-;; POINT-MARKER is the point position in the active buffer.
-;; Otherwise, when multiple windows are visiting the same buffer,
-;; all but one of their points will be overwritten.
-
-;; LOCAL-VARIABLES is an alist from variable names to their
-;; perspective-local values."))
-
-;; (make-variable-frame-local
-;;  (defvar persp-curr nil
-;;    "The current perspective."))
-
-;; (make-variable-frame-local
-;;  (defvar persp-recursive nil
-;;    "The current perspective before beginning a recursive edit."))
-
-;; (make-variable-frame-local
-;;  (defvar persp-last nil
-;;    "The last perspective accessed before the current perspective."))
-
-;; (make-variable-frame-local
-;;  (defvar persp-modestring nil
-;;    "The string displayed in the modeline representing the perspectives."))
-;; (put 'persp-modestring 'risky-local-variable t)
-
 (defvar persp-protected nil
   "Whether a perspective error should cause persp-mode to be disabled.
 Dynamically bound by `persp-protect'.")

--- a/perspective.el
+++ b/perspective.el
@@ -359,7 +359,6 @@ Has no effect when `persp-show-modestring' is nil."
                                               (persp-names)) sep)
                    close)))))
 
-
 (defun persp-format-name (name)
   "Format the perspective name given by NAME for display in the modeline."
   (let ((string-name (format "%s" name)))
@@ -577,7 +576,7 @@ perspective and no others are killed."
   (when (equal name (persp-name (persp--current-persp)))
     (persp-switch (persp-find-some))
     ;; Don't let persp-last get set to the deleted persp.
-    (set-frame-parameter nil 'persp-last (frame-parameter nil 'nil))))
+    (set-frame-parameter nil 'persp-last (persp-find-some))))
 
 (defun persp-rename (name)
   "Rename the current perspective to NAME."


### PR DESCRIPTION
Hi. Now that Emacs 26.1 has been released, I thought it would be a good time to open a PR for my changes :) I've been using Emacs 26 pre-releases for a few months now (plus a few months more on Emacs 25) with my changes on perspective-el, and I haven't run into any issues.
(#64)