### PR TITLE
When removing a buffer, bury it in all windows displaying it

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -592,10 +592,9 @@ See also `persp-switch' and `persp-add-buffer'."
          (kill-buffer buffer))
         ;; Make the buffer go away if we can see it.
         ((get-buffer-window buffer)
-         (let (win)
-           (while (setq win (get-buffer-window buffer))
-             (with-selected-window win
-               (bury-buffer)))))
+         (while (get-buffer-window buffer)
+           (with-selected-window (get-buffer-window buffer)
+             (bury-buffer))))
         (t (bury-buffer buffer)))
   (setf (persp-buffers (persp-curr)) (remq buffer (persp-buffers (persp-curr)))))
 

--- a/perspective.el
+++ b/perspective.el
@@ -591,9 +591,11 @@ See also `persp-switch' and `persp-add-buffer'."
         ((not (persp-buffer-in-other-p buffer))
          (kill-buffer buffer))
         ;; Make the buffer go away if we can see it.
-        ;; TODO: Is it possible to tell if it's visible at all,
-        ;;       rather than just the current buffer?
-        ((eq buffer (current-buffer)) (bury-buffer))
+        ((get-buffer-window buffer)
+         (let (win)
+           (while (setq win (get-buffer-window buffer))
+             (with-selected-window win
+               (bury-buffer)))))
         (t (bury-buffer buffer)))
   (setf (persp-buffers (persp-curr)) (remq buffer (persp-buffers (persp-curr)))))
 


### PR DESCRIPTION
Buries the removed buffer from all windows displaying it.