### PR TITLE
Handle an invalid `persp-point-marker` when activating a perspective

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -463,7 +463,8 @@ perspective's local variables are set."
   (persp-reactivate-buffers (persp-buffers persp))
   (setq buffer-name-history (persp-buffer-history persp))
   (set-window-configuration (persp-window-configuration persp))
-  (goto-char (persp-point-marker persp))
+  (when (marker-position (persp-point-marker persp))
+    (goto-char (persp-point-marker persp)))
   (persp-update-modestring)
   (run-hooks 'persp-activated-hook))
 


### PR DESCRIPTION
This avoids an error that appears when the marker points nowhere. This can happen when the buffer that the marker originally pointed to was killed before switching back to the perspective being activated.