### PR TITLE
Remove references to now-defunct Marmalade repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,10 @@ Each perspective is composed of a window configuration and a set of buffers.
 Switching to a perspective activates its window configuration, and when in a
 perspective only its buffers are available by default.
 
-It's recommended that you install perspective.el from [Marmalade][] using `M-x
-package-install`. Alternately, you may put it in your load path and run
+It's recommended that you install perspective.el from [MELPA](https://melpa.org/). 
+Alternately, you may put it in your load path and run
 `(require 'perspective)`.  Users of Debian 9 or later or Ubuntu 16.04
 or later may simply `apt-get install elpa-perspective`.
-
-[Marmalade]: http://marmalade-repo.org/
 
 ## Usage
 


### PR DESCRIPTION
It would seem the ELPA alternative Marmalade should not be used. 

- The [https://marmalade-repo.org/](https://marmalade-repo.org/) URL has an expired cert (and browsing to it gives the "Your connection is not private" warning) and [gives a TLS error in Emacs since version 25](https://emacs.stackexchange.com/questions/33061/tls-connection-to-marmalade-repo-org443-is-insecure-after-updating-to-emacs-25/35502)
- The Emacs WIKI entry says [it is discontinued](https://www.emacswiki.org/emacs/MarmaladeRepo)