### PR TITLE
Add support for saving and restoring perspectives to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Alternately, you may put it in your load path and run
 `(require 'perspective)`.  Users of Debian 9 or later or Ubuntu 16.04
 or later may simply `apt-get install elpa-perspective`.
 
+
 ## Usage
 
 To activate perspective use `(persp-mode)`.
@@ -34,3 +35,20 @@ Commands are all prefixed by `C-x x`. Here are the main commands:
 - `i`  --  `persp-import`: Import a given perspective from another frame.
 - `n`, `<right>`  --  `persp-next` : Switch to next perspective
 - `p`, `<left>`   --  `persp-prev`: Switch to previous perspective
+
+
+## Saving sessions to disk
+
+A pair of functions, `persp-state-save` and `persp-state-load`, implement
+perspective durability on disk. When called interactively with `M-x`, they
+prompt for files to save sessions to and restore from.
+
+A custom variable, `persp-state-default-file`, sets a default file to use for
+saving and restoring perspectives. When it is set, `persp-state-save` may be
+called non-interactively without an argument and it will save to the file
+referenced by that variable. This makes it easy to automatically save
+perspective sessions when Emacs exists:
+
+```
+(add-hook 'kill-emacs-hook #'persp-state-save)
+```

--- a/perspective.el
+++ b/perspective.el
@@ -1128,6 +1128,9 @@ visible in a perspective as windows, they will be saved as
                (not (or current-prefix-arg
                         (yes-or-no-p "Target file exists. Overwrite? "))))
       (error "persp-state-save cancelled"))
+    ;; if ivy-posframe is in use, get rid of its frame first
+    (when (and (fboundp 'posframe-delete) (boundp 'ivy-posframe-buffer))
+      (posframe-delete ivy-posframe-buffer))
     ;; actually save
     (persp-save)
     (lexical-let ((state-complete (make-persp--state-complete

--- a/perspective.el
+++ b/perspective.el
@@ -1075,7 +1075,7 @@ transient."
                     persps-in-frame))))
 
 ;;;###autoload
-(defun persp-state-save (&optional file interactive?)
+(cl-defun persp-state-save (&optional file interactive?)
   "Save the current perspective state to FILE.
 
 FILE defaults to the value of persp-state-default-file if it is
@@ -1095,7 +1095,8 @@ visible in a perspective as windows, they will be saved as
                                 persp-state-default-file)
                 t))
   (unless persp-mode
-    (error "persp-mode not enabled, nothing to save"))
+    (message "persp-mode not enabled, nothing to save")
+    (return-from persp-state-save))
   (lexical-let ((target-file (if (and file (not (string-equal "" file)))
                                  ;; file provided as argument, just use it
                                  (expand-file-name file)

--- a/perspective.el
+++ b/perspective.el
@@ -177,13 +177,13 @@ Run with the activated perspective active.")
 (defvar persp-state-before-save-hook nil
   "A hook run immediately before saving persp state to disk.")
 
-(defvar persp-state-saved-hook nil
+(defvar persp-state-after-save-hook nil
   "A hook run immediately after saving persp state to disk.")
 
 (defvar persp-state-before-load-hook nil
   "A hook run immediately before loading persp state from disk.")
 
-(defvar persp-state-loaded-hook nil
+(defvar persp-state-after-load-hook nil
   "A hook run immediately after loading persp state from disk.")
 
 (defvar persp-mode-map (make-sparse-keymap)
@@ -1165,7 +1165,7 @@ visible in a perspective as windows, they will be saved as
       ;; create or overwrite target-file:
       (with-temp-file target-file (prin1 state-complete (current-buffer))))
     ;; after hook
-    (run-hooks 'persp-state-saved-hook)))
+    (run-hooks 'persp-state-after-save-hook)))
 
 ;;;###autoload
 (defun persp-state-load (file)
@@ -1232,7 +1232,7 @@ restored."
     ;; cleanup
     (persp-kill tmp-persp-name))
   ;; after hook
-  (run-hooks 'persp-state-loaded-hook))
+  (run-hooks 'persp-state-after-load-hook))
 
 (defalias 'persp-state-restore 'persp-state-load)
 

--- a/perspective.el
+++ b/perspective.el
@@ -1066,6 +1066,7 @@ transient."
 
 (defun persp--state-frame-data ()
   (cl-loop for frame in (frame-list)
+           if (frame-parameter frame 'persp--hash) ; XXX: filter non-perspective-enabled frames
            collect (with-selected-frame frame
                      (lexical-let ((persps-in-frame (make-hash-table :test 'equal))
                                    (persp-names-in-order (persp-names)))
@@ -1142,9 +1143,6 @@ visible in a perspective as windows, they will be saved as
                (not (or current-prefix-arg
                         (yes-or-no-p "Target file exists. Overwrite? "))))
       (error "persp-state-save cancelled"))
-    ;; if ivy-posframe is in use, get rid of its frame first
-    (when (and (fboundp 'posframe-delete) (boundp 'ivy-posframe-buffer))
-      (posframe-delete ivy-posframe-buffer))
     ;; actually save
     (persp-save)
     (lexical-let ((state-complete (make-persp--state-complete

--- a/perspective.el
+++ b/perspective.el
@@ -1012,13 +1012,16 @@ perspective beginning with the given letter."
 
 (defun persp--state-interesting-buffer-p (buffer)
   (and (buffer-name buffer)
-       (buffer-file-name buffer)
-       (not (string-match "^[[:space:]]*\\*" (buffer-name buffer)))))
+       (not (string-match "^[[:space:]]*\\*" (buffer-name buffer)))
+       (or (buffer-file-name buffer)
+           (with-current-buffer buffer (equal major-mode 'dired-mode)))))
 
 (defun persp--state-file-data ()
   (cl-loop for buffer in (buffer-list)
         if (persp--state-interesting-buffer-p buffer)
-        collect (buffer-file-name buffer)))
+        collect (or (buffer-file-name buffer)
+                    (with-current-buffer buffer ; dired special case
+                      default-directory))))
 
 (defun persp--state-window-state-massage (entry persp valid-buffers)
   "This is a primitive code walker. It removes references to

--- a/perspective.el
+++ b/perspective.el
@@ -1178,7 +1178,9 @@ restored."
                 ;; window-state-put to succeed? Something goes haywire with root
                 ;; windows without it.
                 (split-window-horizontally)
-                (window-state-put (persp--state-single-windows state-single) (frame-root-window (selected-frame)))))
+                (window-state-put (persp--state-single-windows state-single)
+                                  (frame-root-window (selected-frame))
+                                  'safe)))
     ;; cleanup
     (persp-kill tmp-persp-name)))
 

--- a/perspective.el
+++ b/perspective.el
@@ -1162,9 +1162,8 @@ visible in a perspective as windows, they will be saved as
     (lexical-let ((state-complete (make-persp--state-complete
                                    :files (persp--state-file-data)
                                    :frames (persp--state-frame-data))))
-      (when (file-exists-p target-file)
-        (delete-file target-file))
-      (append-to-file (prin1-to-string state-complete) nil target-file))
+      ;; create or overwrite target-file:
+      (with-temp-file target-file (prin1 state-complete (current-buffer))))
     ;; after hook
     (run-hooks 'persp-state-saved-hook)))
 

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -294,4 +294,23 @@ persp-test-make-sample-environment."
        (should-persp-equal     '("A" "main")         "A"    nil    "A")) ; pop A
      (should-persp-equal       '("main")             "main" nil    "main"))))
 
+(ert-deftest state-save-and-load ()
+  (unwind-protect
+      (persp-test-with-persp
+        (persp-test-with-files nil (A1 A2 A3 B1 B2 B3 B4)
+          (persp-test-make-sample-environment)
+          (should (= 7 (length (persp-test-buffer-list-all)))) ; sanity check
+          (persp-state-save "state-1.el"))
+        ;; reset perspectives
+        (persp-mode -1)
+        (delete-other-windows)
+        (should (= 0 (length (persp-test-buffer-list-all)))) ; no open files
+        (persp-mode 1)
+        (should (equal (list "main") (sort (persp-names) #'string-lessp)))
+        ;; load it back up
+        (persp-state-load "state-1.el")
+        (should (= 7 (length (persp-test-buffer-list-all)))) ; sanity check again
+        (persp-test-check-sample-environment))
+    (persp-test-clean-files "A1" "A2" "A3" "B1" "B2" "B3" "B4" "state-1.el")))
+
 ;;; test-perspective.el ends here


### PR DESCRIPTION
This is an attempt to add support for durable perspectives. I often have many open, with many buffers and windows in each. Restarting Emacs with so much state (for upgrades or just instability reasons) is really painful.

This has no dependencies aside from perspective-el itself. It provides no integration with desktop-save-mode, though I imagine few persp-mode users rely on it since it doesn't really do the right thing.

It works with my Emacs setup, but definitely needs testing with other people's configurations.