### PR TITLE
Rename perspective-specific scratch buffer when perspective is renamed

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -682,6 +682,14 @@ perspective and no others are killed."
   (interactive "sNew name: ")
   (if (gethash name (perspectives-hash))
       (persp-error "Perspective `%s' already exists" name)
+    ;; rename the perspective-specific *scratch* buffer
+    (let* ((old-scratch-name (format "*scratch* (%s)" (persp-name (persp-curr))))
+           (new-scratch-name (format "*scratch* (%s)" name))
+           (scratch-buffer (get-buffer old-scratch-name)))
+      (when scratch-buffer
+        (with-current-buffer scratch-buffer
+          (rename-buffer new-scratch-name))))
+    ;; rewire the rest of the perspective inside its data structures
     (remhash (persp-name (persp-curr)) (perspectives-hash))
     (puthash name (persp-curr) (perspectives-hash))
     (setf (persp-name (persp-curr)) name)

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -69,4 +69,12 @@
        (lambda (w) (should-not
                     (memq (window-buffer w) (list A1 A2))))))))
 
+(ert-deftest issue-81-renaming-scratch-buffers ()
+  (persp-test-with-persp
+    (persp-switch "A")
+    (should (get-buffer "*scratch* (A)"))
+    (persp-rename "B")
+    (should (not (get-buffer "*scratch* (A)")))
+    (should (get-buffer "*scratch* (B)"))))
+
 ;;; test-perspective.el ends here


### PR DESCRIPTION
Right now, for a perspective named `alpha`, a scratch buffer named `*scratch* (alpha)` is created. If `alpha` is renamed, its scratch buffer is not renamed to follow. This patch fixes things so renaming `alpha` to `bravo` will rename `*scratch* (alpha)` to `*scratch* (bravo)`.

*Edit:* Rebased this branch on top of the current master, with CI enabled. Added a test.