### PR TITLE
Fix error when persp-remove-buffer gets nil as argument

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -625,7 +625,7 @@ Prefers perspectives in the selected frame."
 
 See also `persp-switch' and `persp-add-buffer'."
   (interactive "bRemove buffer from perspective: \n")
-  (setq buffer (get-buffer buffer))
+  (setq buffer (when buffer (get-buffer buffer)))
   (cond ((not (buffer-live-p buffer)))
         ;; Only kill the buffer if no other perspectives are using it
         ((not (persp-buffer-in-other-p buffer))


### PR DESCRIPTION
It's possible for `persp-remove-buffer` to be called with `nil` as the argument to the `buffer` parameter. This often occurs when `persp-kill` is called on a long-lived perspective which has had many buffers added to and remove from it. It calls `persp-remove-buffer` in a loop, and killed buffers are occasionally (?) processed in a way which results in `nil` getting passed in. Simple fix.