### PR TITLE
Prevent pulling random buffers into current persp on buffer kill.

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -823,12 +823,7 @@ See also `persp-add-buffer'."
           ;; If a buffer from outside this perspective was selected, it's because
           ;; this perspective is out of buffers. For lack of any better option, we
           ;; recreate the scratch buffer.
-          ;;
-          ;; If we were just in a scratch buffer, change the name slightly.
-          ;; Otherwise our new buffer will get deleted too.
           (let ((name (concat "*scratch* (" (persp-name (persp-curr)) ")")))
-            (when (and bury-or-kill (equal name (buffer-name old-buffer)))
-              (setq name (concat "*scratch*  (" (persp-name (persp-curr)) ")")))
             (with-selected-window window
               (switch-to-buffer name)
               (funcall initial-major-mode)))


### PR DESCRIPTION
There's currently an annoying bug when killing buffers after switching perspectives: sometimes, a buffer from a different perspective is pulled into the window from which the buffer was killed. I see that an attempt to fix this was made in 2015 with commit 2ccfe107d. Perhaps Emacs behavior changed since then, or perhaps it never quite worked.

The function advised in the previous fix attempt, `switch-to-prev-buffer`, switches to a buffer previously shown in the window. I observed that this can easily pull an unassociated buffer into the current perspective.

This PR includes a two-part fix. First, it makes sure that the `switch-to-prev-buffer` advice does not use the wrongly-updated current buffer list for its own scratch selection logic. Second, it adds its own advice to `window-prev-buffers` and `window-next-buffers` which filters their results by checking it against the list of buffers of the current perspective.