### PR TITLE
Add test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+sudo: required
+# for evm binaries
+dist: trusty
+env:
+  - EMACS_VERSION=26.2
+  - EMACS_VERSION=26.1
+  - EMACS_VERSION=25.1
+  - EMACS_VERSION=24.3
+script:
+  - cd $TRAVIS_BUILD_DIR
+  - git clone https://github.com/rejeep/evm ${TRAVIS_BUILD_DIR}/.evm
+  - export PATH=${TRAVIS_BUILD_DIR}/.evm/bin:${PATH}
+  - evm config path /tmp
+  - evm install emacs-${EMACS_VERSION}-travis --use --skip
+  - emacs --version
+  - make 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+EMACS ?= emacs
+ELFILES := perspective.el
+ELCFILES = $(ELFILES:.el=.elc)
+
+all: test
+
+.PHONY: test
+test:
+	$(EMACS) -nw -Q -batch -L . -l ert $(addprefix -l ,$(wildcard test/*.el)) \
+		--eval "(ert-run-tests-batch-and-exit)"
+
+.PHONY: compile
+compile: $(ELCFILES)
+
+$(ELCFILES): %.elc: %.el
+	$(EMACS) --batch -Q -L . -f batch-byte-compile $<

--- a/perspective.el
+++ b/perspective.el
@@ -28,6 +28,7 @@
 ;; available by default.
 
 (require 'cl-lib)
+(require 'subr-x)                       ; hash-table-values
 
 ;; 'cl' is still required because the use of 'lexical-let'.  'lexical-let' has
 ;; been deprecated since emacs 24.1, and it should be replaced with true

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -15,6 +15,13 @@
 (require 'ert)
 
 (persp-mode 1)
+;; Set frame size so that splitting windows doesn't result in pesky
+;;
+;;    "Window ... too small for splitting"
+;;
+;; errors.
+(set-frame-height (selected-frame) 80)
+(set-frame-width (selected-frame) 160)
 
 (defmacro persp-test-with-temp-buffers (vars &rest body)
   "Bind temporary buffers to VARS and evaluate BODY."
@@ -32,30 +39,20 @@
          ,@cleanup))))
 
 (ert-deftest issue-85 ()
-  (persp-test-with-temp-buffers (b1 b2 b3 b4)
+  (persp-test-with-temp-buffers (A1 A2 B1)
     (persp-switch "A")
-    ;; Show b1 and b2 in two windows of A
-    (switch-to-buffer b1)
-    (select-window (split-window))
-    (switch-to-buffer b2)
-    (should (eq (window-buffer (previous-window)) b1))
-    (should (eq (window-buffer (selected-window)) b2))
+    (select-window (split-window-right))
+    (balance-windows)
+    (switch-to-buffer A1)
+    (switch-to-buffer A2)
     (persp-switch "B")
-    ;; Show b3 and b4 in two windows of B
-    (switch-to-buffer b3)
-    (select-window (split-window))
-    (switch-to-buffer b4)
-    (should (eq (window-buffer (previous-window)) b3))
-    (should (eq (window-buffer (selected-window)) b4))
-    ;; Switch back to A and do the main test
+    (select-window (split-window-right))
+    (switch-to-buffer B1)
     (persp-switch "A")
-    (should (eq (window-buffer (previous-window)) b1))
-    (should (eq (window-buffer (selected-window)) b2))
+    (persp-switch "B")
     (kill-buffer)
-    (should (= (count-windows) 2))
-    (should (eq (window-buffer (previous-window)) b1))
-    (should (eq (window-buffer (selected-window)) b1))))
-
-
+    (walk-windows
+     (lambda (w) (should-not
+             (memq (window-buffer w) (list A1 A2)))))))
 
 ;;; test-perspective.el ends here

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -1,0 +1,61 @@
+;;; test-perspective.el --- Tests for perspective
+
+;; Licensed under the same terms as Emacs and under the MIT license.
+
+;; URL: http://github.com/nex3/perspective-el
+;; Created: 2019-09-18
+;; By: Nathaniel Nicandro <nathanielnicandro@gmail.com>
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'perspective)
+(require 'cl-lib)
+(require 'ert)
+
+(persp-mode 1)
+
+(defmacro persp-test-with-temp-buffers (vars &rest body)
+  "Bind temporary buffers to VARS and evaluate BODY."
+  (declare (indent 1))
+  (let ((binds (cl-loop
+                for var in vars
+                collect `(,var (generate-new-buffer "persp-test"))))
+        (cleanup (cl-loop
+                  for var in vars
+                  collect `(when (buffer-live-p ,var)
+                             (kill-buffer ,var)))))
+    `(let (,@binds)
+       (unwind-protect
+           (progn ,@body)
+         ,@cleanup))))
+
+(ert-deftest issue-85 ()
+  (persp-test-with-temp-buffers (b1 b2 b3 b4)
+    (persp-switch "A")
+    ;; Show b1 and b2 in two windows of A
+    (switch-to-buffer b1)
+    (select-window (split-window))
+    (switch-to-buffer b2)
+    (should (eq (window-buffer (previous-window)) b1))
+    (should (eq (window-buffer (selected-window)) b2))
+    (persp-switch "B")
+    ;; Show b3 and b4 in two windows of B
+    (switch-to-buffer b3)
+    (select-window (split-window))
+    (switch-to-buffer b4)
+    (should (eq (window-buffer (previous-window)) b3))
+    (should (eq (window-buffer (selected-window)) b4))
+    ;; Switch back to A and do the main test
+    (persp-switch "A")
+    (should (eq (window-buffer (previous-window)) b1))
+    (should (eq (window-buffer (selected-window)) b2))
+    (kill-buffer)
+    (should (= (count-windows) 2))
+    (should (eq (window-buffer (previous-window)) b1))
+    (should (eq (window-buffer (selected-window)) b1))))
+
+
+
+;;; test-perspective.el ends here


### PR DESCRIPTION
I wasn't able to reproduce the issue mentioned in #85 with my local Emacs instance so I tried to reproduce it with `emacs -Q`. From there I just needed to add in some boiler plate to setup a test framework with Travis, so I went ahead and did that.

This should make it easier to ensure that no regressions are introduced as `perspective` gets more complex as well as provably show that `perspective` works as intended (we will be able to get rid of issues like #78 and #89).