### PR TITLE
insert initial scratch message into new perspectives

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -382,6 +382,7 @@ buffer called \"*scratch* (NAME)\"."
   (make-persp :name name
     (switch-to-buffer (concat "*scratch* (" name ")"))
     (funcall initial-major-mode)
+    (insert initial-scratch-message)
     (persp-reset-windows)))
 
 (defun persp-reactivate-buffers (buffers)


### PR DESCRIPTION
I have my initial scratch message globally set `nil`, as is sensible, but I often have Org boilerplate in perspective scratch buffers, which I can then save as attachments to the corresponding tasks. Since `perspective-el` supports `initial-major-mode`, it makes sense to also support `initial-scratch-message` for purposes like these.