### PR TITLE
Fix a problem with Emacs Childframe

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -811,9 +811,11 @@ See also `persp-add-buffer'."
     (when ad-return-value
       (let ((buf (ad-get-arg 0))
             (frame (window-frame ad-return-value)))
-        (when (and buf frame)
-          (with-selected-frame frame
-            (persp-add-buffer buf)))))))
+        (unless (and (version<= "26" emacs-version)
+                     (frame-parent frame))
+          (when (and buf frame)
+            (with-selected-frame frame
+              (persp-add-buffer buf))))))))
 
 (defadvice set-window-buffer (after persp-add-buffer-adv)
   "Add BUFFER to the perspective for window's frame.
@@ -822,9 +824,11 @@ See also `persp-add-buffer'."
   (persp-protect
     (let ((buf (ad-get-arg 1))
           (frame (window-frame (ad-get-arg 0))))
-      (when (and buf frame)
-        (with-selected-frame frame
-          (persp-add-buffer buf))))))
+      (unless (and (version<= "26" emacs-version)
+                   (frame-parent frame))
+        (when (and buf frame)
+          (with-selected-frame frame
+            (persp-add-buffer buf)))))))
 
 (defadvice switch-to-prev-buffer (around persp-ensure-buffer-in-persp)
   "Ensure that the selected buffer is in WINDOW's perspective."


### PR DESCRIPTION
Close #79.
Current code does not work when a target frame is a child frame. This patch does not make perspective use the Childframe feature properly, but at least make it work with the feature.