### PR TITLE
Removed warnings that come up from byte compiling.

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -191,6 +191,9 @@ Run with the activated perspective active.")
 (defvar persp-mode-map (make-sparse-keymap)
   "Keymap for perspective-mode.")
 
+(defvar perspective-map nil
+  "Sub-keymap for perspective-mode")
+
 (define-prefix-command 'perspective-map)
 (define-key persp-mode-map persp-mode-prefix-key 'perspective-map)
 

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -31,12 +31,12 @@ tell-tale leading '*' characters)."
 (defun persp-test-buffer-list-all ()
   "Return the list of buffers in Emacs (in all
 perspectives), filtering out temporaries."
-  (remove-if-not #'persp-test-interesting-buffer? (buffer-list)))
+  (cl-remove-if-not #'persp-test-interesting-buffer? (buffer-list)))
 
 (defun persp-test-buffer-list (persp)
   "Return the list of buffers in the current perspective,
 filtering out temporaries."
-  (remove-if-not #'persp-test-interesting-buffer? (persp-buffers persp)))
+  (cl-remove-if-not #'persp-test-interesting-buffer? (persp-buffers persp)))
 
 (defmacro persp-test-with-persp (&rest body)
   "Allow multiple tests to run with reasonable assumption of


### PR DESCRIPTION
This doesn't deal with lexical-let + cl.