### PR TITLE
added check for when frame-parameter returns a string

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -242,8 +242,14 @@ perspective-local values."
 FRAME defaults to the currently selected frame."
   ;; XXX: This must return a non-nil value to avoid breaking frames initialized
   ;; with after-make-frame-functions bound to nil.
-  (or (frame-parameter frame 'persp--curr)
-      (make-persp-internal)))
+  (let ((frame-persp (frame-parameter frame 'persp--curr)))
+    ;; when using certain emacs packages (desktop-mode?) frame-parameter
+    ;; returns a string "Unprintable value" which violates the assumptions of
+    ;; other code that the result from is a perspective struct.
+    (if (or (not frame-persp) (stringp frame-persp)) 
+        (make-persp-internal)
+        frame-persp
+      )))
 
 (defun persp-last (&optional frame)
   "Get the last active perspective in FRAME.


### PR DESCRIPTION
I haven't fully grokked the internals of perspective yet to understand whether this is a complete fix, but it seems to handle the issue I was facing of repeatedly receiving error messages of the form:
```
Wrong type argument: perspective, "Unprintable entity"
```
When using perspective in combination with certain packages such as desktop-mode (I think?), for some reason `(frame-parameter frame 'persp--curr)` returns a string "Unprintable entity" rather than nil, causing persp-curr to return a string rather than a perspective-object.

This seems to be the cause of this issue in spacemacs: https://github.com/syl20bnr/spacemacs/issues/2626.