### PR TITLE
Fix byte-compile error

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -34,7 +34,7 @@
 (require 'bs)                           ; buffer switcher
 
 (defvar ido-temp-list)
-(defvar ido-ignore-buffers)
+(defvar ido-ignore-buffers nil)
 
 ;;; Code:
 


### PR DESCRIPTION
Eager macro-expansion failure: (void-variable ido-ignore-buffers)