### PR TITLE
Fix error symbol’s value as variable is void: union

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -449,7 +449,7 @@ first."
 (defun persp-all-names (&optional not-frame)
   "Return a list of the perspective names for all frames.
 Excludes NOT-FRAME, if given."
-  (cl-reduce 'union
+  (cl-reduce 'cl-union
              (mapcar
               (lambda (frame)
                 (unless (equal frame not-frame)


### PR DESCRIPTION
As a title mention, I encounter this error when I call =persp-import=. I think there is no =union= in emacs lisp but it exists in the common lisp so it should be called =cl-union= instead in emacs-lisp.