### PR TITLE
Fix: persp-switch-buffer use ivy-switch-buffer as caller

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -1260,6 +1260,7 @@ PERSP-SET-IDO-BUFFERS)."
                (cl-remove-if #'null (mapcar #'buffer-name (persp-current-buffers)))
                :preselect (buffer-name (persp-other-buffer (current-buffer)))
                :keymap ivy-switch-buffer-map
+               :caller #'ivy-switch-buffer
                :action #'ivy--switch-buffer-action
                :matcher #'ivy--switch-buffer-matcher)
               ivy-params))
@@ -1293,8 +1294,7 @@ PERSP-SET-IDO-BUFFERS)."
   (declare-function counsel--switch-buffer-unwind "counsel.el")
   (declare-function counsel--switch-buffer-update-fn "counsel.el")
   (persp--switch-buffer-ivy-counsel-helper arg
-                                           (list :caller #'counsel-switch-buffer
-                                                 :unwind #'counsel--switch-buffer-unwind
+                                           (list :unwind #'counsel--switch-buffer-unwind
                                                  :update-fn #'counsel--switch-buffer-update-fn)
                                            #'counsel-switch-buffer))
 


### PR DESCRIPTION
Using counsel-switch-buffer was causing issues with the
all-the-icons-ivy integration, as well as preventing all of the ivy
actions from showing up in the hydra menu. for example, killing marked
buffers is not present in the actions if counsel-switch-buffer is
used, but it does appear when the caller is ivy-switch-buffer

this may cause issues for people that have further customization on
the counsel-switch-buffer caller, but from what i can tell, the
counsel-switch-buffer function doesn't even pass itself down as the
caller in its implementation.

## screenshots

### before

![image](https://user-images.githubusercontent.com/760104/99024964-54b77f80-252d-11eb-805a-f82f9462a178.png)

No icons appear for the buffers, and you can see `[1/5]` actions

### after

![image](https://user-images.githubusercontent.com/760104/99025001-66992280-252d-11eb-8882-0a0ab3a6bda4.png)

Icons appear and you can see `[1/8]` actions