### PR TITLE
Don't invoke persp-switch-hook on norecord

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -630,11 +630,12 @@ If NORECORD is non-nil, do not update the
       (set-frame-parameter nil 'persp--last (persp-curr))
       (when (null persp)
         (setq persp (persp-new name)))
-      (run-hooks 'persp-before-switch-hook)
+      (unless norecord
+        (run-hooks 'persp-before-switch-hook))
       (persp-activate persp)
       (unless norecord
-        (setf (persp-last-switch-time persp) (current-time)))
-      (run-hooks 'persp-switch-hook)
+        (setf (persp-last-switch-time persp) (current-time))
+        (run-hooks 'persp-switch-hook))
       name)))
 
 (defun persp-activate (persp)


### PR DESCRIPTION
`persp-before-switch-hook` and `persp-switch-hook` are being invoked in unexpected cases. Specifically, when `persp-new` is called, the aforementioned hooks are invoked twice due to the use of `persp-switch` in the `with-perspective` macro. Ideally, these hooks should only be invoked as a result of a user action (either switching perspectives interactively or via a bridge like persp-projectile).