### PR TITLE
added persp-list-buffers function

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ to use a Perspective-aware buffer switcher.
 in particular its `ido-switch-buffer` command, is automatically
 Perspective-aware when `persp-mode` is enabled.
 
+**buffer-menu**: Perspective provides a wrapper for
+[`buffer-menu`](https://www.gnu.org/software/emacs/manual/html_node/emacs/List-Buffers.html):
+`persp-buffer-menu`. When this function is called normally, it shows the buffer menu filtered by the current perspective. With a prefix argument, it shows the
+buffer menu of all the buffers in all perspectives.
+
 **`bs.el`**: Perspective provides a wrapper for
 [`bs-show`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Buffer-Menus.html):
 `persp-bs-show`. When this function is called normally, it shows a list of

--- a/perspective.el
+++ b/perspective.el
@@ -826,6 +826,12 @@ Prefers perspectives in the selected frame."
           (persp-switch (cdr other-persp)))
         (switch-to-buffer buffer)))))
 
+(defun persp-list-buffers ()
+  "Like the default C-x C-b, but filters for the current perspective's buffers."
+  (interactive)
+  (switch-to-buffer
+   (list-buffers-noselect nil (seq-filter 'buffer-live-p (persp-current-buffers)))))
+
 (defun persp-remove-buffer (buffer)
   "Disassociate BUFFER with the current perspective.
 

--- a/perspective.el
+++ b/perspective.el
@@ -826,12 +826,6 @@ Prefers perspectives in the selected frame."
           (persp-switch (cdr other-persp)))
         (switch-to-buffer buffer)))))
 
-(defun persp-list-buffers ()
-  "Like the default C-x C-b, but filters for the current perspective's buffers."
-  (interactive)
-  (switch-to-buffer
-   (list-buffers-noselect nil (seq-filter 'buffer-live-p (persp-current-buffers)))))
-
 (defun persp-remove-buffer (buffer)
   "Disassociate BUFFER with the current perspective.
 
@@ -1266,6 +1260,16 @@ PERSP-SET-IDO-BUFFERS)."
                        nil nil nil nil
                        (buffer-name (current-buffer))))))
   (kill-buffer buffer-or-name))
+
+;; Buffer switching integration: buffer-menu
+;;;###autoload
+(defun persp-buffer-menu (arg)
+  "Like the default C-x C-b, but filters for the current perspective's buffers."
+  (interactive "P")
+  (if (and persp-mode (null arg))
+      (switch-to-buffer
+       (list-buffers-noselect nil (seq-filter 'buffer-live-p (persp-current-buffers))))
+    (display-buffer (list-buffers-noselect))))
 
 ;; Buffer switching integration: bs.el.
 ;;;###autoload


### PR DESCRIPTION
I like to use C-x C-b to call the buffer-menu, that allows me to cleanup unused buffers.
But when I use perspective, I usually have 5 to 10 concurrent perspectives, which can amount to a lot of buffers in total, making C-x C-b almost unusable.
This is just a function that does the same, but filters for buffers in the current perspective.

There is not much to the function itself, so I can't really tell if it's just user customization, or if it has its place in perspective itself. Anyway, I find it very useful!
Cheers.