### PR TITLE
Isolate xref--marker-ring between perspectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,10 @@ If you want to group buffers by persp-name in ibuffer buffer, use
             (unless (eq ibuffer-sorting-mode 'alphabetic)
               (ibuffer-do-sort-by-alphabetic))))
 ```
-
+**Xref**: You can isolate `xref--marker-ring` between perspectives by:
+```
+(add-hook 'persp-switch-hook #'persp-set-xref--marker-ring)
+```
 **Helm**: Perspective ships with buffer-listing advice for Helm, so Helm's
 buffer listing code should be automatically Perspective-aware when `persp-mode`
 is enabled. (Older versions of Helm relied on the machinery of `ido-mode` for

--- a/perspective.el
+++ b/perspective.el
@@ -1694,6 +1694,17 @@ restored."
         (pop-to-buffer ibuf)
         (ibuffer-update nil t)))))
 
+;;; --- xref code
+
+(defvar persp-xref--marker-ring (make-hash-table :test 'equal))
+;;;###autoload
+(defun persp-set-xref--marker-ring ()
+  "Set xref--marker-ring per persp."
+  (let ((persp-curr-name (persp-name (persp-curr))))
+    (unless (gethash persp-curr-name persp-xref--marker-ring)
+      (puthash persp-curr-name (make-ring xref-marker-ring-length)
+               persp-xref--marker-ring))
+    (setq xref--marker-ring (gethash persp-curr-name persp-xref--marker-ring))))
 
 ;;; --- done
 


### PR DESCRIPTION
Hi Maintainers,

I would like to make a PR to help users can isolate `xref--marker-ring` between perspectives. I've been using this feature for a long time.
Hope it can be useful for anyone.

Thanks!