### PR TITLE
persp-test-with-persp: use delete rather than delq to remove strings (equal vs eq)

### DIFF
--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -50,7 +50,7 @@ perspectives and open buffers."
      ;; get rid of perspective-specific *scratch* buffers first
      (mapc (lambda (persp)
              (kill-buffer (format "*scratch* (%s)" persp)))
-           (delq persp-initial-frame-name (persp-names)))
+           (delete persp-initial-frame-name (persp-names)))
      (persp-mode -1)
      (mapc #'kill-buffer (persp-test-buffer-list-all))))
 


### PR DESCRIPTION
Hello,

Strings comparison requires `equal`, not `eq`, i.e. `delq` will not remove `"main"` (aka `persp-initial-frame-name`) from `'("main" "A")`.

Using `delq`, `persp-test-with-persp` will try to improperly kill a scratch buffer named `"*scratch* (main)"`, if `persp-names` returns a list like `'("main" "A")`.