### PR TITLE
disabling persp-mode should not mix a buffer's header-line-format with its default (aka global) value

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -1101,10 +1101,11 @@ named collections of buffers and window configurations."
     (setq read-buffer-function nil)
     (set-frame-parameter nil 'persp--hash nil)
     (setq global-mode-string (delete '(:eval (persp-mode-line)) global-mode-string))
-    (set-default 'header-line-format (delete '(:eval (persp-mode-line)) header-line-format))
-    (unless (delete "" header-line-format)
-      ;; need to set header-line-format to nil to completely remove the header from the buffer
-      (set-default 'header-line-format nil))))
+    (let ((default-header-line-format (default-value 'header-line-format)))
+      (set-default 'header-line-format (delete '(:eval (persp-mode-line)) default-header-line-format))
+      (unless (delete "" default-header-line-format)
+        ;; need to set header-line-format to nil to completely remove the header from the buffer
+        (set-default 'header-line-format nil)))))
 
 (defun persp-init-frame (frame)
   "Initialize the perspectives system in FRAME.

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -129,6 +129,34 @@ deleted at cleanup."
   ;; no buffers should be open after all this
   (should (= 0 (length (persp-test-buffer-list-all)))))
 
+(ert-deftest basic-persp-header-line-format-default-value ()
+  "Disabling `persp-mode' should properly restore the default
+value of `header-line-format'.
+
+Updating `header-line-format' default value using a buffer
+local value of it is a mistake."
+  (let ((persp-show-modestring 'header)
+	(default-header-line-format (default-value 'header-line-format)))
+    ;; Since `persp-test-with-persp' may change in the future, do not
+    ;; use it.  We need to avoid switching to another buffer than the
+    ;; *dummy* buffer just before `persp-mode' is disabled.  For this
+    ;; test to work, a buffer with a locally modified header needs to
+    ;; be the current buffer when `persp-mode' is disabled.
+    (persp-mode 1)
+    (should (switch-to-buffer "*dummy*"))
+    (should (equal (buffer-name) "*dummy*"))
+    (setq header-line-format "custom header")
+    ;; This is just being paranoid about the header's default value.
+    (should-not (equal header-line-format default-header-line-format))
+    (should-not (equal header-line-format (default-value 'header-line-format)))
+    (persp-mode -1)
+    (should (equal (buffer-name) "*dummy*"))
+    (should (equal header-line-format "custom header"))
+    (let ((updated-header-line-format (default-value 'header-line-format)))
+      (should (equal updated-header-line-format default-header-line-format)))
+    ;; Cleanup.
+    (kill-buffer "*dummy*")))
+
 (ert-deftest basic-persp-creation-deletion ()
   (persp-test-with-persp
     (should (equal (list "main") (persp-names)))


### PR DESCRIPTION
Hello,

I noticed that disabling `persp-mode` while in a buffer with a locally modified `header-line-format` updates the default value of `header-line-format` to the buffer's local value... i.e. turning off `persp-mode` while in `*Buffer List*` (which has its own `header-line-format` set up) will set the header of buffers which do not have a locally `header-line-format` set up to the same header of `*Buffer List*`.

In this PR there's also an ert test to prove it... ;)