### PR TITLE
Add commands to add/remove marked buffers to/from persp via ibuffer

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -1752,8 +1752,32 @@ restored."
         (pop-to-buffer ibuf)
         (ibuffer-update nil t)))))
 
+
+;;; --- modify perspectives from ibuffer
 
-;;; --- xref code
+;;;###autoload
+(defun persp-ibuffer-add-marked-buffers ()
+  "Add all marked buffers within ibuffer to the current perspective."
+  (interactive)
+  (unless (featurep 'ibuffer)
+    (user-error "IBuffer not loaded"))
+  (declare-function ibuffer-get-marked-buffers "ibuffer.el")
+  (dolist (buffer (ibuffer-get-marked-buffers))
+    (persp-add-buffer buffer)))
+
+;;;###autoload
+(defun persp-ibuffer-remove-marked-buffers ()
+  "Remove all marked buffers within ibuffer from the current perspective."
+  (interactive)
+  (unless (featurep 'ibuffer)
+    (user-error "IBuffer not loaded"))
+  (declare-function ibuffer-get-marked-buffers "ibuffer.el")
+  (dolist (buffer (ibuffer-get-marked-buffers))
+    (persp-remove-buffer buffer)))
+    ;; TODO: if the current ibuffer is filtered to the current perspective, update
+    ;; the view to not show the removed buffers
+
+ ;;; --- xref code
 
 ;; xref is not available in Emacs 24, so be careful:
 (when (require 'xref nil t)

--- a/perspective.el
+++ b/perspective.el
@@ -1769,6 +1769,12 @@ restored."
   (persp--ibuffer-function-on-marked #'persp-add-buffer))
 
 ;;;###autoload
+(defun persp-ibuffer-set-marked-buffers ()
+  "Add all marked buffers within ibuffer to the current perspective."
+  (interactive)
+  (persp--ibuffer-function-on-marked #'persp-set-buffer))
+
+;;;###autoload
 (defun persp-ibuffer-remove-marked-buffers ()
   "Add all marked buffers within ibuffer to the current perspective."
   (interactive)

--- a/perspective.el
+++ b/perspective.el
@@ -1755,27 +1755,26 @@ restored."
 
 ;;; --- modify perspectives from ibuffer
 
+(defun persp--ibuffer-function-on-marked (persp-buffer-function)
+  "Apply PERSP-BUFFER-FUNCTION to all buffers marked in ibuffer."
+  (unless (featurep 'ibuffer)
+    (user-error "IBuffer not loaded"))
+  (declare-function ibuffer-get-marked-buffers "ibuffer.el")
+  (mapc persp-buffer-function (ibuffer-get-marked-buffers)))
+
 ;;;###autoload
 (defun persp-ibuffer-add-marked-buffers ()
   "Add all marked buffers within ibuffer to the current perspective."
   (interactive)
-  (unless (featurep 'ibuffer)
-    (user-error "IBuffer not loaded"))
-  (declare-function ibuffer-get-marked-buffers "ibuffer.el")
-  (dolist (buffer (ibuffer-get-marked-buffers))
-    (persp-add-buffer buffer)))
+  (persp--ibuffer-function-on-marked #'persp-add-buffer))
 
 ;;;###autoload
 (defun persp-ibuffer-remove-marked-buffers ()
-  "Remove all marked buffers within ibuffer from the current perspective."
+  "Add all marked buffers within ibuffer to the current perspective."
   (interactive)
-  (unless (featurep 'ibuffer)
-    (user-error "IBuffer not loaded"))
-  (declare-function ibuffer-get-marked-buffers "ibuffer.el")
-  (dolist (buffer (ibuffer-get-marked-buffers))
-    (persp-remove-buffer buffer)))
-    ;; TODO: if the current ibuffer is filtered to the current perspective, update
-    ;; the view to not show the removed buffers
+  (persp--ibuffer-function-on-marked #'persp-remove-buffer))
+;; TODO: if the current ibuffer is filtered to the current perspective, update
+;; the view to not show the removed buffers
 
  ;;; --- xref code
 


### PR DESCRIPTION
See [discussion](https://github.com/nex3/perspective-el/issues/54#issuecomment-915592609) in #54.
 
This allows to easily add and remove multiple buffers to/from a perspective. These functions have to be called from an ibuffer-buffer, after some buffers have been marked (e.g. via `m`).

I hope I have done the declare-function, the error-raising, autoloading etc. correctly. I'm used to writing elisp for my own emacs config, but haven't done much coding for packages yet, so these are things new to me, but I just tried to do the same as the existing functions.

## Potential TODO's

- [ ] Maybe add some default keybindings, a keymap or something like this for better ibuffer integration. Alternatively, just add an example configuration to the README.

- [ ] In any case, add some documentation for the functions to the README, e.g. in an _"Add/remove multiple buffers at once"_ section.

- [ ] Think whether we want to remove the marks after the buffers have been successfully added.

- [ ] When calling `persp-ibuffer-remove-marked-buffers` after `persp-ibuffer`, with an ibuffer buffer filtered to the current perspective, we could remove the removed buffers from the ibuffer view. This should not happen from an unfiltered ibuffer showing all perspective buffers.

- [ ] The commands work only in ibuffer, outside ibuffer they result in the error
  ```
  ibuffer-map-lines: Assertion failed: (derived-mode-p 'ibuffer-mode)
  ```
  Should we raise a custom user-error if the commands are called from outside ibuffer or is passing the assertion enough?