### PR TITLE
Do not require which-key and xref

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -312,9 +312,7 @@ Run with the activated perspective active.")
 (define-key perspective-map (kbd "9") (lambda () (interactive) (persp-switch-by-number 9)))
 (define-key perspective-map (kbd "0") (lambda () (interactive) (persp-switch-by-number 10)))
 
-(declare-function which-key-mode "which-key.el")
-(when (fboundp 'which-key-mode)
-  (require 'which-key)
+(with-eval-after-load 'which-key
   (declare-function which-key-add-keymap-based-replacements "which-key.el")
   (when (fboundp 'which-key-add-keymap-based-replacements)
     (which-key-add-keymap-based-replacements perspective-map

--- a/perspective.el
+++ b/perspective.el
@@ -1759,8 +1759,7 @@ restored."
 ;;; --- xref code
 
 ;; xref is not available in Emacs 24, so be careful:
-(when (require 'xref nil t)
-
+(with-eval-after-load 'xref
   (defvar persp--xref-marker-ring (make-hash-table :test 'equal))
 
   (defun persp--set-xref-marker-ring ()


### PR DESCRIPTION
Loading persp is the slowest part of my emacs startup. This helps a bit by not requiring things that I can require later, as needed. I do not know if there is a reason not to do this, but it seems better to respond to things loading rather than force their loading.