### PR TITLE
speedup persp-maybe-kill-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp-mode`: when enabling the mode, activate `persp-maybe-kill-buffer-adv`.
+- `persp-maybe-kill-buffer-adv`: due to `persp-maybe-kill-buffer` amendments, after calling `kill-buffer` force update the `current-buffer` to the current window's buffer.
 - `persp-maybe-kill-buffer`: remove buffers directly accessing the frame's hash table for performance reasons.
 - `persp-maybe-kill-buffer`: read perspectives' buffers directly accessing the frame's hash table for performance reasons.
 - `persp-maybe-kill-buffer`: implement `persp-feature-flag-directly-kill-ido-ignore-buffers`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ERT tests variables
 
+- `ido-ignore-buffers`: set to detect temporary buffers (aka buffers starting with a space).
 - `persp-feature-flag-directly-kill-ido-ignore-buffers`: unset flag (disable).
 - `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: set flag (enable).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp-maybe-kill-buffer`: remove buffers directly accessing the frame's hash table for performance reasons.
 - `persp-maybe-kill-buffer`: read perspectives' buffers directly accessing the frame's hash table for performance reasons.
 - `persp-maybe-kill-buffer`: implement `persp-feature-flag-directly-kill-ido-ignore-buffers`.
 - `persp-maybe-kill-buffer`: kill `persp--make-ignore-buffer-rx` temporary buffers (aka `ido-ignore-buffers`) skipping checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp-maybe-kill-buffer`: read perspectives' buffers directly accessing the frame's hash table for performance reasons.
 - `persp-maybe-kill-buffer`: implement `persp-feature-flag-directly-kill-ido-ignore-buffers`.
 - `persp-maybe-kill-buffer`: kill `persp--make-ignore-buffer-rx` temporary buffers (aka `ido-ignore-buffers`) skipping checks.
 - `persp-kill`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `persp-feature-flag-directly-kill-ido-ignore-buffers`: allow/disallow `persp-maybe-kill-buffer` to kill `ido-ignore-buffers` skipping checks (default: enable).
+- `persp-feature-flag-directly-kill-ido-ignore-buffers`: allow/disallow `persp-maybe-kill-buffer` to kill `ido-ignore-buffers` skipping checks (default: disable).
 - `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: enables/disables `persp-maybe-kill-buffer` (default: disable).
 - `persp-switch-to-scratch-buffer`: interactive function to switch to the current perspective's scratch buffer, creating one if missing.
 - `persp-get-scratch-buffer`: utility function to properly get/create a scratch buffer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### ERT tests variables
+
+- `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: set flag (enable).
+
+
 ### ERT tests added
 
 - `basic-persp-switch-to-scratch-buffer`: evaluate `persp-switch-to-scratch-buffer`.
@@ -45,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: enables/disables `persp-maybe-kill-buffer` (default: disable).
 - `persp-switch-to-scratch-buffer`: interactive function to switch to the current perspective's scratch buffer, creating one if missing.
 - `persp-get-scratch-buffer`: utility function to properly get/create a scratch buffer.
 - `persp-forget-buffer`: disassociate buffer with perspective without the risk of killing it.  This balances `persp-add-buffer`.  Newly created buffers via `get-buffer-create` are rogue buffers not found in any perspective, this function allows to get back to that state.
@@ -55,6 +61,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp-kill`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.
+- `persp-mode`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.
 - `perspective-map`: Add binding `C-x x B` to call `persp-switch-to-scratch-buffer`.
 - `persp-other-buffer`: call `persp-get-scratch-buffer` to get/create a scratch buffer.
 - `persp-new`: call `persp-get-scratch-buffer` to get/create a scratch buffer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ERT tests variables
 
+- `persp-feature-flag-directly-kill-ido-ignore-buffers`: unset flag (disable).
 - `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: set flag (enable).
 
 
@@ -50,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `persp-feature-flag-directly-kill-ido-ignore-buffers`: allow/disallow `persp-maybe-kill-buffer` to kill `ido-ignore-buffers` skipping checks (default: enable).
 - `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: enables/disables `persp-maybe-kill-buffer` (default: disable).
 - `persp-switch-to-scratch-buffer`: interactive function to switch to the current perspective's scratch buffer, creating one if missing.
 - `persp-get-scratch-buffer`: utility function to properly get/create a scratch buffer.
@@ -61,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp-maybe-kill-buffer`: implement `persp-feature-flag-directly-kill-ido-ignore-buffers`.
 - `persp-maybe-kill-buffer`: kill `persp--make-ignore-buffer-rx` temporary buffers (aka `ido-ignore-buffers`) skipping checks.
 - `persp-kill`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.
 - `persp-mode`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### ERT tests added
 
+- `basic-persp-killing-buffers-benchmark`: benchmark `persp-maybe-kill-buffer`.
 - `basic-persp-switch-to-scratch-buffer`: evaluate `persp-switch-to-scratch-buffer`.
 - `basic-persp-get-scratch-buffer`: test scratch buffers conformity and creation.
 - `basic-persp-forget-buffer`: evaluate `persp-forget-buffer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp-maybe-kill-buffer`: kill `persp--make-ignore-buffer-rx` temporary buffers (aka `ido-ignore-buffers`) skipping checks.
 - `persp-kill`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.
 - `persp-mode`: implement `persp-feature-flag-prevent-killing-last-buffer-in-perspective`.
 - `perspective-map`: Add binding `C-x x B` to call `persp-switch-to-scratch-buffer`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `persp`: add dirty flag to the structure, that when set means that at least one buffer was removed from the perspective manipulating the frame's hash table without updating the perspective's windows configuration.
+- `persp-maybe-kill-buffer`: set a perspective's dirty flag when removing buffers accessing the frame's hash table directly.
+- `persp-activate`: forget windows buffers which do not belong to the current perspective, hence updating the windows configuration; this is required since `persp-maybe-kill-buffer` no longer updates the perspectives windows configuration.
 - `persp-mode`: when enabling the mode, activate `persp-maybe-kill-buffer-adv`.
 - `persp-maybe-kill-buffer-adv`: due to `persp-maybe-kill-buffer` amendments, after calling `kill-buffer` force update the `current-buffer` to the current window's buffer.
 - `persp-maybe-kill-buffer`: remove buffers directly accessing the frame's hash table for performance reasons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - `persp-feature-flag-directly-kill-ido-ignore-buffers`: allow/disallow `persp-maybe-kill-buffer` to kill `ido-ignore-buffers` skipping checks (default: disable).
-- `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: enables/disables `persp-maybe-kill-buffer` (default: disable).
+- `persp-feature-flag-prevent-killing-last-buffer-in-perspective`: enables/disables `persp-maybe-kill-buffer` (default: enable).
 - `persp-switch-to-scratch-buffer`: interactive function to switch to the current perspective's scratch buffer, creating one if missing.
 - `persp-get-scratch-buffer`: utility function to properly get/create a scratch buffer.
 - `persp-forget-buffer`: disassociate buffer with perspective without the risk of killing it.  This balances `persp-add-buffer`.  Newly created buffers via `get-buffer-create` are rogue buffers not found in any perspective, this function allows to get back to that state.

--- a/perspective.el
+++ b/perspective.el
@@ -113,7 +113,7 @@ save state when exiting Emacs."
   :group 'perspective-mode
   :type 'file)
 
-(defcustom persp-feature-flag-prevent-killing-last-buffer-in-perspective nil
+(defcustom persp-feature-flag-prevent-killing-last-buffer-in-perspective t
   "Experimental feature flag: prevent killing the last buffer in a perspective."
   :group 'perspective-mode
   :type 'boolean)

--- a/perspective.el
+++ b/perspective.el
@@ -118,6 +118,17 @@ save state when exiting Emacs."
   :group 'perspective-mode
   :type 'boolean)
 
+(defcustom persp-feature-flag-directly-kill-ido-ignore-buffers t
+  "Experimental feature flag: kill temporary buffers skipping checks.
+
+For performance reasons, a `persp-maybe-kill-buffer' call is allowed
+to kill `ido-ignore-buffers' (aka temporary buffers) skipping checks
+when this feature flag isn't nil.
+
+Temproray buffers usually have a name starting with a space."
+  :group 'perspective-mode
+  :type 'boolean)
+
 
 ;;; --- implementation
 
@@ -905,8 +916,9 @@ See also `persp-remove-buffer'."
       ;; XXX: For performance reasons, always allow killing off obviously
       ;; temporary buffers. According to Emacs convention, these buffers' names
       ;; start with a space.
-      (when (string-match-p ignore-rx bufstr)
-        (cl-return-from persp-maybe-kill-buffer t))
+      (and persp-feature-flag-directly-kill-ido-ignore-buffers
+           (string-match-p ignore-rx bufstr)
+           (cl-return-from persp-maybe-kill-buffer t))
       (dolist (name (persp-names))
         (let ((buffer-names (persp-get-buffer-names name)))
           (when (member bufstr buffer-names)

--- a/perspective.el
+++ b/perspective.el
@@ -900,11 +900,12 @@ See also `persp-remove-buffer'."
   (persp-protect
     (let* ((buffer (current-buffer))
            (bufstr (buffer-name buffer))
+           (ignore-rx (persp--make-ignore-buffer-rx))
            candidates-for-removal candidates-for-keeping)
       ;; XXX: For performance reasons, always allow killing off obviously
       ;; temporary buffers. According to Emacs convention, these buffers' names
       ;; start with a space.
-      (when (string-match-p (rx string-start (one-or-more blank)) bufstr)
+      (when (string-match-p ignore-rx bufstr)
         (cl-return-from persp-maybe-kill-buffer t))
       (dolist (name (persp-names))
         (let ((buffer-names (persp-get-buffer-names name)))

--- a/perspective.el
+++ b/perspective.el
@@ -1200,6 +1200,13 @@ is non-nil or with prefix arg, don't switch to the new perspective."
         (persp-update-modestring)
       (persp-activate persp))))
 
+(defadvice kill-buffer (after persp-maybe-kill-buffer-adv)
+  "Force set the `current-buffer' to the window's buffer.
+
+See also `persp-maybe-kill-buffer'."
+  (persp-protect
+    (set-buffer (window-buffer))))
+
 (defadvice switch-to-buffer (after persp-add-buffer-adv)
   "Add BUFFER to the current perspective.
 
@@ -1289,6 +1296,7 @@ named collections of buffers and window configurations."
           (setq persp-started-after-server-mode t))
         ;; TODO: Convert to nadvice, which has been available since 24.4 and is
         ;; the earliest Emacs version Perspective supports.
+        (ad-activate 'kill-buffer)
         (ad-activate 'switch-to-buffer)
         (ad-activate 'display-buffer)
         (ad-activate 'set-window-buffer)

--- a/perspective.el
+++ b/perspective.el
@@ -118,7 +118,7 @@ save state when exiting Emacs."
   :group 'perspective-mode
   :type 'boolean)
 
-(defcustom persp-feature-flag-directly-kill-ido-ignore-buffers t
+(defcustom persp-feature-flag-directly-kill-ido-ignore-buffers nil
   "Experimental feature flag: kill temporary buffers skipping checks.
 
 For performance reasons, a `persp-maybe-kill-buffer' call is allowed

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -24,6 +24,7 @@
 
 ;; Set feature flag(s):
 (customize-set-variable 'persp-feature-flag-prevent-killing-last-buffer-in-perspective t)
+(customize-set-variable 'persp-feature-flag-directly-kill-ido-ignore-buffers nil)
 
 (defun persp-test-interesting-buffer? (buf)
   "Return t if BUF is a non-temporary buffer (i.e., lacks

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -11,6 +11,7 @@
 ;;; Code:
 
 (require 'perspective)
+(require 'benchmark)
 (require 'cl-lib)
 (require 'ert)
 
@@ -1293,6 +1294,276 @@ the number of buffers, shared or not, that it has, though."
       (should (equal (list "main") (sort (persp-names) #'string-lessp)))))
   ;; Forced cleanup when tests failed.
   (persp-test-kill-extra-buffers " *foo*" "*dummy*"))
+
+(ert-deftest basic-persp-killing-buffers-benchmark ()
+  "Benchmark `persp-maybe-kill-buffer' duty cycle.
+
+This test is just informative, but it may crash Emacs.  If it
+happens, try to run the test again.
+
+Put a load on `persp-maybe-kill-buffer' disabling performance
+flags and creating a multitude of buffers, which the function
+should evaluate when one buffer is killed."
+  (let (result
+        (n_perspectives 20)
+        (n_regular-buffers 50)
+        (n_temporary-buffers 50)
+        (regular-buffer-name "*dummy*")
+        (temporary-buffer-name " *foo*")
+        perspectives regular-buffers temporary-buffers
+        ;; `benchmark-progn' is not available before Emacs 27.1
+        (timings (lambda (t) ;; requires `benchmark-run' result
+                   (let ((elapsed (nth 0 t))
+                         (gcs-done (nth 1 t))
+                         (gc-elapsed (nth 2 t)))
+                     (format "Elapsed time: %fs%s"
+                             elapsed
+                             (if (> gcs-done 0)
+                                 (format " (%fs in %d GCs)" gc-elapsed gcs-done)
+                               ""))))))
+    ;; Starting conditions.
+    (persp-test-kill-extra-buffers regular-buffer-name temporary-buffer-name)
+    ;; Generate random perspective names.
+    (cl-loop repeat n_perspectives do (push (symbol-name (cl-gensym)) perspectives))
+    ;; Generate random regular buffer names.
+    (cl-loop repeat n_regular-buffers do (push (symbol-name (cl-gensym)) regular-buffers))
+    ;; Generate random temporary buffer names.
+    (cl-loop repeat n_temporary-buffers do (push (symbol-name (cl-gensym " ")) temporary-buffers))
+    ;; Add a killable target buffer as regular buffer.
+    (push regular-buffer-name regular-buffers)
+    ;; Add a killable target buffer as temporary buffer.
+    (push temporary-buffer-name temporary-buffers)
+    (message "")
+    (message "Benchmark - persp-maybe-kill-buffer - begin")
+    (message "%s perspectives * (%s regular buffers + %s temporary buffers)"
+             (length perspectives) (length regular-buffers) (length temporary-buffers))
+    ;; Disable `persp-maybe-kill-buffer'.
+    (message "")
+    (message "persp-maybe-kill-buffer disabled - kill regular buffer")
+    (message "(persp-set-buffer \"%s\")" regular-buffer-name)
+    (let ((persp-feature-flag-prevent-killing-last-buffer-in-perspective nil))
+      ;; Kill regular buffer via `kill-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with regular and temporary buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer regular-buffer-name)
+        (should (persp-test-buffer-in-persps regular-buffer-name (persp-current-name)))
+        (should-not (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (kill-buffer regular-buffer-name)))
+        (should-not (get-buffer regular-buffer-name))
+        (message "%s: (kill-buffer \"%s\")" (funcall timings result) regular-buffer-name))
+      ;; Kill regular buffer via `persp-remove-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with regular and temporary buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer regular-buffer-name)
+        (should (persp-test-buffer-in-persps regular-buffer-name (persp-current-name)))
+        (should-not (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (persp-remove-buffer regular-buffer-name)))
+        (should-not (get-buffer regular-buffer-name))
+        (message "%s: (persp-remove-buffer \"%s\")" (funcall timings result) regular-buffer-name)))
+    ;; Enable performance flag(s).
+    (message "")
+    (message "persp-maybe-kill-buffer performance flag(s) - kill regular buffer")
+    (message "(persp-set-buffer \"%s\")" regular-buffer-name)
+    (let ((persp-feature-flag-directly-kill-ido-ignore-buffers t))
+      ;; Kill regular buffer via `kill-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with regular and temporary buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer regular-buffer-name)
+        (should (persp-test-buffer-in-persps regular-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (kill-buffer regular-buffer-name)))
+        (should-not (get-buffer regular-buffer-name))
+        (message "%s: (kill-buffer \"%s\")" (funcall timings result) regular-buffer-name))
+      ;; Kill regular buffer via `persp-remove-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with regular and temporary buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer regular-buffer-name)
+        (should (persp-test-buffer-in-persps regular-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (persp-remove-buffer regular-buffer-name)))
+        (should-not (get-buffer regular-buffer-name))
+        (message "%s: (persp-remove-buffer \"%s\")" (funcall timings result) regular-buffer-name)))
+    ;; Disable performance flag(s).
+    (message "")
+    (message "persp-maybe-kill-buffer w/o performance flag(s) - kill regular buffer")
+    (message "(persp-set-buffer \"%s\")" regular-buffer-name)
+    (let ((persp-feature-flag-directly-kill-ido-ignore-buffers nil))
+      ;; Kill regular buffer via `kill-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with regular and temporary buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer regular-buffer-name)
+        (should (persp-test-buffer-in-persps regular-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (kill-buffer regular-buffer-name)))
+        (should-not (get-buffer regular-buffer-name))
+        (message "%s: (kill-buffer \"%s\")" (funcall timings result) regular-buffer-name))
+      ;; Kill regular buffer via `persp-remove-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with regular and temporary buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer regular-buffer-name)
+        (should (persp-test-buffer-in-persps regular-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (persp-remove-buffer regular-buffer-name)))
+        (should-not (get-buffer regular-buffer-name))
+        (message "%s: (persp-remove-buffer \"%s\")" (funcall timings result) regular-buffer-name)))
+    ;; Disable `persp-maybe-kill-buffer'.
+    (message "")
+    (message "persp-maybe-kill-buffer disabled - kill temporary buffer")
+    (message "(persp-set-buffer \"%s\")" temporary-buffer-name)
+    (let ((persp-feature-flag-prevent-killing-last-buffer-in-perspective nil))
+      ;; Kill regular buffer via `kill-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with temporary and regular buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer temporary-buffer-name)
+        (should (persp-test-buffer-in-persps temporary-buffer-name (persp-current-name)))
+        (should-not (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (kill-buffer temporary-buffer-name)))
+        (should-not (get-buffer temporary-buffer-name))
+        (message "%s: (kill-buffer \"%s\")" (funcall timings result) temporary-buffer-name))
+      ;; Kill regular buffer via `persp-remove-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with temporary and regular buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer temporary-buffer-name)
+        (should (persp-test-buffer-in-persps temporary-buffer-name (persp-current-name)))
+        (should-not (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (persp-remove-buffer temporary-buffer-name)))
+        (should-not (get-buffer temporary-buffer-name))
+        (message "%s: (persp-remove-buffer \"%s\")" (funcall timings result) temporary-buffer-name)))
+    ;; Enable performance flag(s).
+    (message "")
+    (message "persp-maybe-kill-buffer performance flag(s) - kill temporary buffer")
+    (message "(persp-set-buffer \"%s\")" temporary-buffer-name)
+    (let ((persp-feature-flag-directly-kill-ido-ignore-buffers t))
+      ;; Kill regular buffer via `kill-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with temporary and regular buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer temporary-buffer-name)
+        (should (persp-test-buffer-in-persps temporary-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (kill-buffer temporary-buffer-name)))
+        (should-not (get-buffer temporary-buffer-name))
+        (message "%s: (kill-buffer \"%s\")" (funcall timings result) temporary-buffer-name))
+      ;; Kill regular buffer via `persp-remove-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with temporary and regular buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer temporary-buffer-name)
+        (should (persp-test-buffer-in-persps temporary-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (persp-remove-buffer temporary-buffer-name)))
+        (should-not (get-buffer temporary-buffer-name))
+        (message "%s: (persp-remove-buffer \"%s\")" (funcall timings result) temporary-buffer-name)))
+    ;; Disable performance flag(s).
+    (message "")
+    (message "persp-maybe-kill-buffer w/o performance flag(s) - kill temporary buffer")
+    (message "(persp-set-buffer \"%s\")" temporary-buffer-name)
+    (let ((persp-feature-flag-directly-kill-ido-ignore-buffers nil))
+      ;; Kill regular buffer via `kill-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with temporary and regular buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer temporary-buffer-name)
+        (should (persp-test-buffer-in-persps temporary-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (kill-buffer temporary-buffer-name)))
+        (should-not (get-buffer temporary-buffer-name))
+        (message "%s: (kill-buffer \"%s\")" (funcall timings result) temporary-buffer-name))
+      ;; Kill regular buffer via `persp-remove-buffer'.
+      (persp-test-with-persp
+        ;; Populate perspectives with temporary and regular buffers.
+        (dolist (persp perspectives)
+          (persp-switch persp)
+          (dolist (buffer temporary-buffers)
+            (should (switch-to-buffer buffer)))
+          (dolist (buffer regular-buffers)
+            (should (switch-to-buffer buffer))))
+        ;; Benchmark `persp-maybe-kill-buffer'.
+        (persp-set-buffer temporary-buffer-name)
+        (should (persp-test-buffer-in-persps temporary-buffer-name (persp-current-name)))
+        (should (memq 'persp-maybe-kill-buffer kill-buffer-query-functions))
+        (setq result (benchmark-run 1 (persp-remove-buffer temporary-buffer-name)))
+        (should-not (get-buffer temporary-buffer-name))
+        (message "%s: (persp-remove-buffer \"%s\")" (funcall timings result) temporary-buffer-name)))
+    (message "")
+    (message "Benchmark - persp-maybe-kill-buffer - end")
+    (message "")
+    ;; Cleanup.
+    (persp-test-kill-extra-buffers regular-buffer-name temporary-buffer-name)))
 
 (ert-deftest basic-persp-forget-buffer ()
   "Test `persp-forget-buffer' and `persp-remove-buffer'.

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -26,6 +26,9 @@
 (customize-set-variable 'persp-feature-flag-prevent-killing-last-buffer-in-perspective t)
 (customize-set-variable 'persp-feature-flag-directly-kill-ido-ignore-buffers nil)
 
+;; Set `ido-ignore-buffers' to detect temporary buffers.
+(customize-set-variable 'ido-ignore-buffers '("\\` "))
+
 (defun persp-test-interesting-buffer? (buf)
   "Return t if BUF is a non-temporary buffer (i.e., lacks
 tell-tale leading '*' characters)."


### PR DESCRIPTION
@gcv: This PR possibly fixes #168 (decreased processing speed during a `persp-maybe-kill-buffer` duty cycle).  It may relate also to #164 and #167.

**DISCLAIMER: `basic-persp-killing-buffers-benchmark` may crash Emacs.  If it does, try to repeat the test.**

**In brief: `persp-maybe-kill-buffer` removes buffers manipulating the frame's hash table directly, and sets a perspective's dirty flag to update the windows configuration when the perspective is `persp-activate` re-activated.**

The first commit of this PR is just a starting point I needed, a remainder from where to begin, a plain changelog update.

**Switching perspective repeatedly is time consuming**.  In reference to `perps-maybe-kill-buffer`, **the speed improvements gained with this PR are due to removing buffers manipulating the frame's hash table directly**, rather than switching to a perspective first.

The major difference between _switching-perspective-then-removing-buffer_ and _remove-buffer-from-hash-table_ is that the former also updates a perspective's windows configuration.

Not updating a windows configuration means that once a perspective is switched to via `persp-activate` (aka re-activated), removed buffers still present in the windows configuration will be pulled back into the perspective... Unless a **dirty flag** is used...

Once set, a perspective's dirty flag allows to update a windows configuration only when it's time to do it, i.e. during a `persp-activate` cycle, buffers not belonging to the perspective (pulled back in by the windows configuration) will be forgotten by the perspective automatically.

# persp-maybe-kill-buffer: different approaches, from last PR's commit to old behavior

Each section below has a descriptive header of the `persp-maybe-kill-buffer` behavior.  Then, pseudo code and benchmark results will follow (a buffer is killed to collect the timings of `kill-buffer`, the `persp-maybe-kill-buffer` duty cycle is executed only when enabled by the `persp-feature-flag-prevent-killing-last-buffer-in-perspective` flag).

Benchmark creating `20 perspectives * (51 regular buffers + 51 temporary buffers)`.  All buffers are shared between perspectives, including `"*dummy*"` and `" *foo*"`.  Before killig a buffer, the buffer is `persp-set-buffer` to the current perspective, to remove it from other perspectives (allowing it to be killed for sure, but still be part of a perspective).  The sequence is:
1. Set/Unset performance flag(s) and/or enable/disable `persp-maybe-kill-buffer`;
2. populate with perspectives and buffers;
3. (persp-set-buffer buffer);
4. (benchmark-progn (kill-buffer buffer));
5. do the step 2 again;
6. do the step 3 again;
7. (benchmark-progn (persp-remove-buffer buffer));
8. change the conditions at the step 1;
9. run from step 2 to 9 until all possibilities are exausted.

Performance flag enabled/disabled: `persp-feature-flag-directly-kill-ido-ignore-buffers`

Enables/Disables `persp-maybe-kill-buffer`: `persp-feature-flag-prevent-killing-last-buffer-in-perspective`

## verify buffer accessing the frame's hash table, remove from hash table and set dirty flag
```
... idle ...

kill-buffer -> persp-maybe-kill-buffer

read buffer

for each persp in frame's hash table {
  if should remove buffer from persp {
    if not current persp {
      (setf (persp-dirty persp) t)
      (setf (persp-buffers persp) other-buffers)
    }
  }
  if should remove buffer from current persp {
    (persp-forget-buffer buffer)
  }
  if should not keep buffer in some persp {
    return and complete kill-buffer
  }
}

... idle ...

persp-switch -> persp-activate

read persp

restore persp's buffers
restore persp's windows configuration
if persp has dirty flag set {
  for each window {
    if window's buffer not in persp {
      (persp-forget-buffer buffer)
    }
  }
}



persp-maybe-kill-buffer disabled - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.001365s: (kill-buffer "*dummy*")
Elapsed time: 0.000135s: (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer performance flag(s) - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.001006s: (kill-buffer "*dummy*")
Elapsed time: 0.001326s: (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer w/o performance flag(s) - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.001060s: (kill-buffer "*dummy*")
Elapsed time: 0.001267s: (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer disabled - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000038s: (kill-buffer " *foo*")
Elapsed time: 0.000138s: (persp-remove-buffer " *foo*")

persp-maybe-kill-buffer performance flag(s) - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000056s: (kill-buffer " *foo*")
Elapsed time: 0.000295s: (persp-remove-buffer " *foo*")

persp-maybe-kill-buffer w/o performance flag(s) - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000360s: (kill-buffer " *foo*")
Elapsed time: 0.000571s: (persp-remove-buffer " *foo*")
```

## verify buffer accessing the frame's hash table, then switch perspectives and remove buffer
```
... idle ...

kill-buffer -> persp-maybe-kill-buffer

verify buffer accessing the frame's hash table

if buffer is killable {
  switching all eligible perspectives {
    (setf (persp-current-buffers) other-buffers)
  }
  return and complete kill-buffer
} else if keep buffer in some perspective {
  switching all other perspectives {
    (persp-forget-buffer buffer)
  }
  return
}



persp-maybe-kill-buffer disabled - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.001315s: (kill-buffer "*dummy*")
Elapsed time: 0.000131s: (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer performance flag(s) - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.434958s (0.322209s in 14 GCs): (kill-buffer "*dummy*")
Elapsed time: 0.423267s (0.309523s in 13 GCs): (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer w/o performance flag(s) - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.435926s (0.324754s in 13 GCs): (kill-buffer "*dummy*")
Elapsed time: 0.418884s (0.305229s in 12 GCs): (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer disabled - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000024s: (kill-buffer " *foo*")
Elapsed time: 0.000128s: (persp-remove-buffer " *foo*")

persp-maybe-kill-buffer performance flag(s) - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000052s: (kill-buffer " *foo*")
Elapsed time: 0.000271s: (persp-remove-buffer " *foo*")

persp-maybe-kill-buffer w/o performance flag(s) - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.392657s (0.283619s in 10 GCs): (kill-buffer " *foo*")
Elapsed time: 0.404069s (0.293969s in 10 GCs): (persp-remove-buffer " *foo*")
```

## verify buffer switching perspectives, then switch perspectives and remove buffer
```
... idle ...

kill-buffer -> persp-maybe-kill-buffer

switch all perspectives and verify buffer

if buffer is killable {
  switching all eligible perspectives {
    (setf (persp-current-buffers) other-buffers)
  }
  return and complete kill-buffer
} else if keep buffer in some perspective {
  switching all other perspectives {
    (persp-forget-buffer buffer)
  }
  return
}



persp-maybe-kill-buffer disabled - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.001369s: (kill-buffer "*dummy*")
Elapsed time: 0.000126s: (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer performance flag(s) - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.404920s (0.293942s in 13 GCs): (kill-buffer "*dummy*")
Elapsed time: 0.417669s (0.304375s in 13 GCs): (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer w/o performance flag(s) - kill regular buffer
(persp-set-buffer "*dummy*")
Elapsed time: 0.435914s (0.321106s in 13 GCs): (kill-buffer "*dummy*")
Elapsed time: 0.428524s (0.312342s in 12 GCs): (persp-remove-buffer "*dummy*")

persp-maybe-kill-buffer disabled - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000030s: (kill-buffer " *foo*")
Elapsed time: 0.000140s: (persp-remove-buffer " *foo*")

persp-maybe-kill-buffer performance flag(s) - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.000045s: (kill-buffer " *foo*")
Elapsed time: 0.000273s: (persp-remove-buffer " *foo*")

persp-maybe-kill-buffer w/o performance flag(s) - kill temporary buffer
(persp-set-buffer " *foo*")
Elapsed time: 0.432575s (0.318429s in 11 GCs): (kill-buffer " *foo*")
Elapsed time: 0.437974s (0.323620s in 11 GCs): (persp-remove-buffer " *foo*")
```
