### PR TITLE
Fix restore of multibyte buffer names when loading state from file.

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -1863,7 +1863,7 @@ restored."
         (frame-count 0)
         (state-complete (read
                          (with-temp-buffer
-                           (insert-file-contents-literally file)
+                           (insert-file-contents file)
                            (buffer-string)))))
     ;; open all files in a temporary perspective to avoid polluting "main"
     (persp-switch tmp-persp-name)


### PR DESCRIPTION
Hi!

When the state is saved to a file, the multibyte-encoded names of the buffers are saved as they are, but when the state is loaded, they are restored as backslash sequences. Thus, the configuration of the buffers changes on save/restore.  Such names look terrible in the mode-line, some commands do not work correctly with them.
I suppose if someone gave a multibyte name to the buffer before the state was saved, it works after the restore as well.
Or if you have some reason to act this way, maybe I could add a custom option to control this? 

Thank you