### PR TITLE
Add consult integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,17 @@ show buffers in all perspectives. In addition, Perspective adds actions to
 to the prefix-argument version) and to remove buffers from the current
 perspective.
 
+**Consult**: Perspective provides `persp-consult-source` source that will list
+buffers in current perspective. You can hide default buffer source
+and add `persp-consult-source` to `consult-buffer-sources` for consult
+to only list buffers in current perspective, note that you can access
+list of all buffers by filtering with `b` key. Example configuration:
+
+```emacs-lisp
+(consult-customize consult--source-buffer :hidden t :default nil)
+(add-to-list consult-buffer-sources persp-consult-source)
+```
+
 **Ivy / Counsel**: Perspective provides two commands for listing buffers using
 Ivy and Counsel: `persp-ivy-switch-buffer` and `persp-counsel-switch-buffer`.
 When these functions are called normally, they show a list of buffers filtered

--- a/README.md
+++ b/README.md
@@ -249,13 +249,15 @@ perspective.
 **Consult**: Perspective provides `persp-consult-source` source that will list
 buffers in current perspective. You can hide default buffer source
 and add `persp-consult-source` to `consult-buffer-sources` for consult
-to only list buffers in current perspective, note that you can access
-list of all buffers by filtering with `b` key. Example configuration:
+to only list buffers in current perspective like so:
 
 ```emacs-lisp
 (consult-customize consult--source-buffer :hidden t :default nil)
-(add-to-list consult-buffer-sources persp-consult-source)
+(add-to-list 'consult-buffer-sources 'persp-consult-source)
 ```
+Note that you can still access list of all buffers in all perspectives by
+[narrowing](https://github.com/minad/consult#narrowing-and-grouping)
+using prefix `b`
 
 **Ivy / Counsel**: Perspective provides two commands for listing buffers using
 Ivy and Counsel: `persp-ivy-switch-buffer` and `persp-counsel-switch-buffer`.

--- a/perspective.el
+++ b/perspective.el
@@ -1546,6 +1546,20 @@ PERSP-SET-IDO-BUFFERS)."
         (ibuffer))
     (ibuffer)))
 
+;; Buffer switching integration: Consult
+
+(defvar persp-consult-source
+  (list :name     "Perspective"
+        :narrow   ?s
+        :category 'buffer
+        :state    #'consult--buffer-state
+        :history  'buffer-name-history
+        :default  t
+        :items
+        (lambda () (consult--buffer-query :sort 'visibility
+                                          :predicate 'persp-is-current-buffer
+                                          :as #'buffer-name))))
+
 ;; Buffer switching integration: Ivy.
 ;;
 ;; An alternative implementation, which has the drawback of not allowing a

--- a/perspective.el
+++ b/perspective.el
@@ -1548,17 +1548,21 @@ PERSP-SET-IDO-BUFFERS)."
 
 ;; Buffer switching integration: Consult
 
-(defvar persp-consult-source
-  (list :name     "Perspective"
-        :narrow   ?s
-        :category 'buffer
-        :state    #'consult--buffer-state
-        :history  'buffer-name-history
-        :default  t
-        :items
-        (lambda () (consult--buffer-query :sort 'visibility
-                                          :predicate 'persp-is-current-buffer
-                                          :as #'buffer-name))))
+(with-eval-after-load 'consult
+  (declare-function consult--buffer-state "consult.el")
+  (declare-function consult--buffer-query "consult.el")
+
+  (defvar persp-consult-source
+    (list :name     "Perspective"
+          :narrow   ?s
+          :category 'buffer
+          :state    #'consult--buffer-state
+          :history  'buffer-name-history
+          :default  t
+          :items
+          #'(lambda () (consult--buffer-query :sort 'visibility
+                                            :predicate 'persp-is-current-buffer
+                                            :as #'buffer-name)))))
 
 ;; Buffer switching integration: Ivy.
 ;;


### PR DESCRIPTION
This adds new variable `persp-consult-source` which is source that can be used
with `consult-buffer-sources` and instruction to README on how to use it