### PR TITLE
Feature: persp-purge-initial-persp-on-save - purges the inital persp upon save

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,10 @@ customize`). The following are likely to be of most interest:
   the modeline).
 - `persp-modestring-short`: When set to `t`, show a shortened modeline string
   with only the current perspective instead of the full list. Defaults to `nil`.
+- `persp-purge-initial-persp-on-save`: When set to `t`, will kill all buffers
+  of the initial perspective upon calling `perps-state-save`. The buffers whose name
+  match a regexp in the list `persp-purge-initial-persp-on-save-exceptions` won't
+  get killed.
 
 To change keys used after the prefix key, with `use-package` you can do:
 

--- a/perspective.el
+++ b/perspective.el
@@ -143,6 +143,20 @@ TODO: Eventually eliminate this setting?"
 (defalias 'persp-avoid-killing-last-buffer-in-perspective
   'persp-feature-flag-prevent-killing-last-buffer-in-perspective)
 
+(defcustom persp-purge-initial-persp-on-save nil
+  "When non-nil, kills all the buffers in the initial perspective upon state save.
+
+When calling `persp-state-save`, all the buffers in the initial perspective (\"main\" by default)
+are killed, expect the buffers whose name match the regex blabla"
+  :group 'perspective-mode
+  :type 'boolean)
+
+(defcustom persp-purge-initial-persp-on-save-exceptions nil
+  "Buffer whose name match with any regexp of this list
+won't be killed upon state save if persp-purge-initial-persp-on-save is t"
+  :group 'perspective-mode
+  :type '(repeat regexp))
+
 
 ;;; --- implementation
 
@@ -1930,6 +1944,11 @@ to the perspective's *scratch* buffer."
                         :order persp-names-in-order
                         :merge-list (frame-parameter nil 'persp-merge-list))))))
 
+(defun persp-purge-exception-p (buffer)
+  (let (result)
+    (dolist (exception persp-purge-initial-persp-on-save-exceptions result)
+      (setq result (or result (string-match-p exception (buffer-name buffer)))))))
+
 ;;;###autoload
 (cl-defun persp-state-save (&optional file interactive?)
   "Save the current perspective state to FILE.
@@ -1986,6 +2005,8 @@ visible in a perspective as windows, they will be saved as
       (user-error "Cancelled persp-state-save"))
     ;; before hook
     (run-hooks 'persp-state-before-save-hook)
+    (when persp-purge-initial-persp-on-save
+      (mapc 'kill-buffer (cl-remove-if #'persp-purge-exception-p (persp-all-get persp-initial-frame-name nil))))
     ;; actually save
     (persp-save)
     (let ((state-complete (make-persp--state-complete


### PR DESCRIPTION
This is a small feature that I use since quite a few months:
I basically use my initial perspective as a "scratchpad" for quickly editing files. I do so, so I don't clutter my "project" perspectives with buffers that are very temporary and that I might forget to kill right away, plus, they usually don't belong to any of my longer-term perspectives anyway.

With this feature, I can basically open all the temporary buffers in my initial persp and then upon using `persp-state-save`, the inital persp will get "purged", meaning all buffers, besides the ones that have names that match any regexp of the list `persp-purge-initial-persp-on-save-exceptions` will be killed. For the moment, I just have my `init.el` there, because it's the only file I consistently need to edit daily :)

Cheers!