### PR TITLE
persp-reactive-buffers: preserve recent visited order of buffers

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -663,11 +663,11 @@ buffer called \"*scratch* (NAME)\"."
 Returns BUFFERS with all non-living buffers removed.
 
 See also `other-buffer'."
-  (cl-loop for buf in (reverse buffers)
-           when (buffer-live-p buf)
-           collect buf into living-buffers
+  (cl-loop for buf in (reverse (buffer-list))
+           when (member buf buffers)
+           collect buf into result-buffers
            and do (switch-to-buffer buf)
-           finally return (nreverse living-buffers)))
+           finally return result-buffers))
 
 (defun persp-set-local-variables (vars)
   "Set the local variables given in VARS.

--- a/perspective.el
+++ b/perspective.el
@@ -664,7 +664,7 @@ Returns BUFFERS with all non-living buffers removed.
 
 See also `other-buffer'."
   (cl-loop for buf in (reverse (buffer-list))
-           when (member buf buffers)
+           when (and (buffer-live-p buf) (member buf buffers))
            collect buf into result-buffers
            and do (switch-to-buffer buf)
            finally return result-buffers))


### PR DESCRIPTION
Previously, after switching to a perspective, the recent-visit order of buffers will be changed because `persp-reactive-buffers` revisits buffers based on `persp-current-buffers` which is in a fixed order. With this PR, `persp-reactive-buffers` revisits the buffers based on `(buffer-list)`