### PR TITLE
Fix name in `.mailmap`

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,2 @@
-Natalie Weizenbaum <nex342@gmail.com> Nathan Weizenbaum <nex342@gmail.com>
-Natalie Weizenbaum <nex342@gmail.com> Nathan Weizenbaum <nweiz@google.com>
+Natalie Weizenbaum <nex342@gmail.com>
+Natalie Weizenbaum <nweiz@google.com>


### PR DESCRIPTION
Found the commit title "Fix my name" interesting and the fact that it was 10 years old, so I looked at it and noticed that `.mailmap` had incorrect names and it bothered me too much not to create a PR.

Sorry if this is weird.