### PR TITLE
Trust the default perspective scratch buffer contents

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -312,7 +312,12 @@ Create it if the current perspective doesn't have one yet."
         (when (and (zerop (buffer-size))
                    initial-scratch-message)
           (insert (substitute-command-keys initial-scratch-message))
-          (set-buffer-modified-p nil))))
+          (set-buffer-modified-p nil))
+        ;; Turn flymake off to prevent the annoying error in the
+        ;; minibuffer
+        (when (and (require 'flymake nil t)
+                   (boundp flymake-mode))
+          (flymake-mode -1))))
     scratch-buffer))
 
 (defun persp-switch-to-scratch-buffer ()


### PR DESCRIPTION
Without this, by default trying to interact with a new perspective
puts the "Disabline elisp-flymake-byte-compile due to untrusted
content" message to popup in the minibuffer creating an annoying UX.

Regular scratch should trusted in Emacs[1][2] but that doesn't propogate
here

[1] https://lists.gnu.org/archive/html/emacs-devel/2025-02/msg01023.html
[2] https://github.com/emacs-mirror/emacs/commit/8b6c6cffd1f7