### PR TITLE
docs: fix consult-source-buffer symbol name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ and add `persp-consult-source` to `consult-buffer-sources` for consult
 to only list buffers in current perspective like so:
 
 ```emacs-lisp
-(consult-customize consult--source-buffer :hidden t :default nil)
+(consult-customize consult-source-buffer :hidden t :default nil)
 (add-to-list 'consult-buffer-sources persp-consult-source)
 ```
 Note that you can still access list of all buffers in all perspectives by


### PR DESCRIPTION
In consult 3.2 `consult--source-buffer` was renamed to `consult-source-buffer`.
https://github.com/minad/consult/commit/a2aaf3a9ff01a1b75b08e61b5ab890eb119b5dbd