### PR TITLE
Preserve the current buffer in with-perspective

### DIFF
--- a/perspective.el
+++ b/perspective.el
@@ -225,18 +225,22 @@ After BODY is evaluated, frame parameters are reset to their original values."
      ,@body))
 
 (defmacro with-perspective (name &rest body)
-  "Switch to the perspective given by NAME while evaluating BODY."
+  "Switch to the perspective given by NAME while evaluating BODY.
+Restore the current buffer afterwards: switching perspectives
+restores window configurations, which would otherwise leave the
+selected window's buffer current instead of the caller's buffer."
   (declare (indent 1))
   (let ((old (cl-gensym)))
     `(progn
        (let ((,old (with-current-perspective (persp-current-name)))
              (last-persp-cache (persp-last))
              (result))
-         (unwind-protect
-             (progn
-               (persp-switch ,name 'norecord)
-               (setq result (progn ,@body)))
-           (when ,old (persp-switch ,old 'norecord)))
+         (save-current-buffer
+           (unwind-protect
+               (progn
+                 (persp-switch ,name 'norecord)
+                 (setq result (progn ,@body)))
+             (when ,old (persp-switch ,old 'norecord))))
          (set-frame-parameter nil 'persp--last last-persp-cache)
          result))))
 

--- a/test/test-perspective.el
+++ b/test/test-perspective.el
@@ -1622,6 +1622,21 @@ has its scratch buffer set as `current-buffer'."
         (cl-loop for buf in (list A1 A2 B1 B2) do
                  (should-not (memq buf (persp-buffers (persp-curr)))))))))
 
+(ert-deftest basic-persp-with-perspective-preserves-current-buffer ()
+  "Verify that with-perspective does not change the current buffer.
+The perspective round-trip restores window configurations, which
+would otherwise leave the selected window's buffer current. This
+matters for callers operating on a buffer not shown in any window,
+e.g. code running inside `find-file-noselect' or mode hooks."
+  (persp-test-with-persp
+    (persp-switch "A")
+    (persp-switch "main")
+    (with-temp-buffer
+      (let ((buf (current-buffer)))
+        (with-perspective "A"
+          (current-buffer))
+        (should (eq (current-buffer) buf))))))
+
 (ert-deftest basic-persp-get-scratch-buffer ()
   "Verify that creating a new perspective also creates its own
 *scratch* buffer, if missing, or adds the existing one.  If


### PR DESCRIPTION
## Problem

`with-perspective` leaks a change of the current buffer to its caller. The perspective round-trip (`persp-switch` out and back) restores window configurations, and `set-window-configuration` makes the selected window's buffer current. For callers whose current buffer *is* displayed this goes unnoticed, but callers operating on a buffer not shown in any window get their current buffer switched out from under them:

```elisp
(with-temp-buffer
  (let ((buf (current-buffer)))
    (with-perspective "some-other-persp"
      nil)
    (eq (current-buffer) buf)))   ;; ⇒ nil — current buffer is now the selected window's buffer
```

Any code path that calls `persp-current-buffers*` with INCLUDE-GLOBAL (e.g. `persp-is-current-buffer buf t`, or the `persp-consult-source` items predicate) hits this whenever a frame-global perspective exists.

## Real-world impact

I traced a pair of confusing Emacs bugs back to this: a sesman/CIDER session filter calling `persp-is-current-buffer buf t` runs inside `clojure-mode-hook` (CIDER session lookup) and therefore inside `find-file-noselect`. Because `find-file-noselect-1` returns `(current-buffer)` after running hooks, the leak made it return the *wrong buffer* — so xref/consult jumps landed at the right line number in the wrong file, and the remaining mode hooks ran against the wrong buffer, leaving newly opened files half-initialized (no font-lock, no minor modes).

## Fix

Wrap the switch/body/switch-back in `save-current-buffer`. Behavior *during* BODY is unchanged (the body still runs after `persp-switch`, exactly as before); only the post-macro state is restored. Bare `persp-switch` is unaffected — as an interactive command, making the restored window's buffer current is its intended behavior, and `basic-persp-switching` continues to assert that.

A regression test is included (fails on master, passes with this change).

## CONTRIBUTING.org checklist

- `make test`: 33/33 pass (Emacs 30.2).
- Byte-compilation (`make compile`): warning set identical to master (no new warnings).
- MELPA sandbox: built the package via `make recipes/perspective` against this branch (the tar builds; the badge-image step fails locally for unrelated ImageMagick font reasons) and installed the resulting tar with `package-install-file` in `emacs -Q --batch` with an empty `package-user-dir` — compiles with only the warnings already present on master and loads cleanly with no other packages installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
