### PR TITLE
persp-current-buffers*: read frame-global buffers without switching perspectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Perspective was started in 2008 and this log was only added in 2021.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [Unreleased]
+
+### Fixed
+
+- `persp-current-buffers*` (and therefore `persp-is-current-buffer`, `persp-buffer-filter`, and friends) with INCLUDE-GLOBAL no longer switches perspectives to read the frame global perspective's buffer list. The `with-perspective` round-trip restored window configurations from inside what callers treat as a pure predicate; when reached from code evaluated during redisplay (for example a menu-bar item's `:enable` form calling a buffer predicate), the mid-redisplay window-configuration change reallocated glyph matrices under the display engine and segfaulted Emacs. Also protects the frame global perspective's live buffer list from the destructive `delete-dups`.
+
+
 ## [2.22] — 2026-06-23
 
 ### Fixed

--- a/perspective.el
+++ b/perspective.el
@@ -268,10 +268,25 @@ the frame global perspective."
     (delete-dups
      (append (persp-current-buffers)
              (when (member persp-frame-global-perspective-name (persp-names))
-               (with-perspective persp-frame-global-perspective-name
+               ;; Read the frame global perspective's buffer list directly
+               ;; instead of round-tripping through `with-perspective': that
+               ;; runs `persp-switch' (twice), which restores window
+               ;; configurations — a side effect callers of this function
+               ;; (buffer predicates and filters) don't expect, and one that
+               ;; crashes Emacs when it happens inside redisplay, e.g. when
+               ;; a menu-bar item's :enable form reaches this through a
+               ;; buffer predicate. `copy-sequence' keeps the destructive
+               ;; `delete-dups' above off the perspective's live buffer
+               ;; list.
+               (let ((global-buffers
+                      (persp-buffers
+                       (gethash persp-frame-global-perspective-name
+                                (perspectives-hash)))))
                  (if persp-frame-global-perspective-include-scratch-buffer
-                     (persp-current-buffers)
-                   (remove (persp-get-scratch-buffer) (persp-current-buffers)))))))))
+                     (copy-sequence global-buffers)
+                   (remove (persp-get-scratch-buffer
+                            persp-frame-global-perspective-name)
+                           global-buffers))))))))
 
 (defun persp-current-buffer-names (&optional include-global)
   "Return a list of names of all living buffers in the current perspective.


### PR DESCRIPTION
## Problem

`persp-current-buffers*` with `INCLUDE-GLOBAL` reads the frame global perspective's buffer list via `with-perspective`, which runs `persp-switch` twice (there and back). Each switch restores a window configuration. Callers of `persp-current-buffers*` / `persp-is-current-buffer` / `persp-buffer-filter` reasonably treat them as pure predicates, so this side effect is surprising — and it turns out to be fatal in one realistic scenario:

Emacs evaluates menu-bar `:enable` forms **during redisplay** (`update_menu_bar → menu_item_eval_property`). If such a form reaches a perspective buffer predicate (in my case: CIDER's menu `:enable (cider-connected-p)` → sesman session lookup → a sesman-to-perspective filter → `persp-is-current-buffer buf t`), the `with-perspective` round-trip executes `delete-other-windows` mid-redisplay, which calls `adjust_frame_glyphs` and reallocates the window's glyph matrices while `display_line` holds pointers into them. Emacs 31.0.90 segfaults 100% reproducibly (`set_cursor_from_row` computes a garbage `w->cursor.vpos` from a stale row pointer; the next `display_line` indexes ~340 GB out of bounds). I debugged this under lldb down to the exact instructions, and caught the `persp-switch → delete-other-windows → adjust_glyph_matrix` chain live with a breakpoint while `redisplay_internal` was on the stack. A hardening report to bug-gnu-emacs is in flight, but the crash is trivially avoided by not switching perspectives here at all.

## Fix

Read the frame global perspective's buffer list directly from `perspectives-hash`. `persp-get-scratch-buffer` already accepts the perspective name, so the scratch-buffer exclusion behaves identically. This follows the same approach as #226 (`persp-maybe-kill-buffer`: avoid switching perspectives).

Bonus fix: the previous code returned the global perspective's **live** buffer list as the shared tail of `append`, exposing it to the destructive `delete-dups`; `copy-sequence` now protects it.

## Testing

`make test`: 32/33 pass, matching pristine HEAD on the same Emacs — the one failure (`basic-persp-window-prev-buffers`) pre-exists on master under Emacs 31.0.90 batch mode and is unrelated (verified by running the suite on an unpatched checkout). Byte-compiles with no new warnings. The equivalent change applied at the configuration level (checking `persp-buffers` membership directly, bypassing the `with-perspective` round-trip) eliminates the segfault in the originally crashing CIDER + perspective session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3SLHGSnQuGu2QukBqs1wd
